### PR TITLE
hypervisor: call qmp.Monitor.Connect where needed

### DIFF
--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -131,6 +131,10 @@ func (hv *Hypervisor) connectDomain(name string) (*qemu.Domain, error) {
 		return nil, err
 	}
 
+	if err := mon.Connect(); err != nil {
+		return nil, err
+	}
+
 	dom, err := qemu.NewDomain(mon, name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes a bug that didn't apply to the libvirt driver, but does to the QMP socket driver.

r: @benlemasurier 