### PR TITLE
internal/shellexec: new package to wrap shelling out, add plumbing

### DIFF
--- a/hypervisor/libvirt.go
+++ b/hypervisor/libvirt.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/digitalocean/go-qemu/internal/shellexec"
 	"github.com/digitalocean/go-qemu/qmp"
 )
 
@@ -13,6 +14,7 @@ var _ Driver = &LibvirtDriver{}
 // shelling out to 'virsh'.
 type LibvirtDriver struct {
 	uri *url.URL
+	cmd shellexec.Command
 }
 
 // NewMonitor creates a new qmp.Monitor using libvirt with 'virsh'.
@@ -23,7 +25,7 @@ func (d *LibvirtDriver) NewMonitor(domain string) (qmp.Monitor, error) {
 // DomainNames retrieves all hypervisor domain names using libvirt with
 // 'virsh'.
 func (d *LibvirtDriver) DomainNames() ([]string, error) {
-	return virshList(d.uri.String())
+	return d.virshList()
 }
 
 // NewLibvirtDriver configures a LibvirtDriver using the provided hypervisor URI.
@@ -37,14 +39,24 @@ func NewLibvirtDriver(uri string) (*LibvirtDriver, error) {
 		return nil, err
 	}
 
+	// Shell out to virsh to perform management actions
+	cmd := &shellexec.SystemCommand{}
+
 	return &LibvirtDriver{
 		uri: u,
+		cmd: cmd,
 	}, nil
 }
 
 // virshList shells out to 'virsh list --all --name' to produce a list of domain names.
-func virshList(uri string) ([]string, error) {
-	out, err := qmp.Virsh(uri, "list", "--all", "--name")
+func (d *LibvirtDriver) virshList() ([]string, error) {
+	out, err := qmp.Virsh(
+		d.cmd,
+		d.uri.String(),
+		"list",
+		"--all",
+		"--name",
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/shellexec/shellexec.go
+++ b/internal/shellexec/shellexec.go
@@ -1,0 +1,55 @@
+// Copyright 2016 The go-qemu Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package shellexec provides the Command interface to allowing testing of
+// actions which shell out.
+package shellexec
+
+import (
+	"io"
+	"os/exec"
+)
+
+// A Command is a command which is typically executed by shelling out.
+type Command interface {
+	// Prepare copies a Command and prepares it for use with the input binary
+	// name and arguments.
+	Prepare(name string, args ...string) Command
+
+	// Standard methods used by os/exec.Command.
+	Kill() error
+	Output() ([]byte, error)
+	Start() error
+	StdoutPipe() (io.ReadCloser, error)
+	Wait() error
+}
+
+var _ Command = &SystemCommand{}
+
+// A SystemCommand is a wrapper type for os/exec.Command.
+type SystemCommand struct {
+	*exec.Cmd
+}
+
+// Prepare prepares a copy of a SystemCommand for shelling out to
+// a binary with arguments.
+func (cmd SystemCommand) Prepare(name string, args ...string) Command {
+	cmd.Cmd = exec.Command(name, args...)
+	return &cmd
+}
+
+// Kill kills the process wrapped by an os/exec.Command.
+func (cmd *SystemCommand) Kill() error {
+	return cmd.Cmd.Process.Kill()
+}

--- a/internal/shellexec/shellexec_test.go
+++ b/internal/shellexec/shellexec_test.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The go-qemu Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shellexec
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSystemCommand(t *testing.T) {
+	sys := &SystemCommand{}
+
+	cmd := sys.Prepare("echo", "hello", "world")
+
+	if reflect.DeepEqual(sys, cmd) {
+		t.Fatalf("Prepare should create a copy; SystemCommands should not be equal:\n- %#v\n- %#v",
+			sys, cmd)
+	}
+
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("unexpected error")
+	}
+
+	if want, got := "hello world\n", string(out); want != got {
+		t.Fatalf("unexpected output:\n- want: %q\n-  got: %q",
+			want, got)
+	}
+}


### PR DESCRIPTION
This way, we can test interactions that shell out as well.

Supersedes #22.

r: @benlemasurier 