### PR TITLE
Pure golang QMP Monitor over libvirt RPC

### DIFF
--- a/qmp/libvirtrpc/rpc.go
+++ b/qmp/libvirtrpc/rpc.go
@@ -1,0 +1,679 @@
+// Copyright 2016 The go-qemu Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package libvirtrpc is a pure Go implementation of the libvirt RPC protocol.
+// For more information on the protocol, see https://libvirt.org/internals/rpc.html
+package libvirtrpc
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	"github.com/davecgh/go-xdr/xdr2"
+	"github.com/digitalocean/go-qemu/qmp"
+)
+
+var _ qmp.Monitor = &Monitor{}
+
+// request and response types
+const (
+	// Call is used when making calls to the remote server.
+	Call = iota
+
+	// Reply indicates a server reply.
+	Reply
+
+	// Message is an asynchronous notification.
+	Message
+
+	// Stream represents a stream data packet.
+	Stream
+
+	// CallWithFDs is used by a client to indicate the request has
+	// arguments with file descriptors.
+	CallWithFDs
+
+	// ReplyWithFDs is used by a server to indicate the request has
+	// arguments with file descriptors.
+	ReplyWithFDs
+)
+
+// request and response statuses
+const (
+	// StatusOK is always set for method calls or events.
+	// For replies it indicates successful completion of the method.
+	// For streams it indicates confirmation of the end of file on the stream.
+	StatusOK = iota
+
+	// StatusError for replies indicates that the method call failed
+	// and error information is being returned. For streams this indicates
+	// that not all data was sent and the stream has aborted.
+	StatusError
+
+	// StatusContinue is only used for streams.
+	// This indicates that further data packets will be following.
+	StatusContinue
+)
+
+// magic program numbers
+// see: https://libvirt.org/git/?p=libvirt.git;a=blob_plain;f=src/remote/remote_protocol.x;hb=HEAD
+const (
+	programVersion   = 1
+	programRemote    = 0x20008086
+	programQEMU      = 0x20008087
+	programKeepAlive = 0x6b656570
+)
+
+// libvirt procedure identifiers
+const (
+	procConnectOpen        = 1
+	procConnectClose       = 2
+	procDomainLookupByName = 23
+)
+
+// qemu procedure identifiers
+const (
+	qemuDomainMonitor                       = 1
+	qemuConnectDomainMonitorEventRegister   = 4
+	qemuConnectDomainMonitorEventDeregister = 5
+	qemuDomainMonitorEvent                  = 6
+)
+
+const (
+	// packet length, in bytes.
+	packetLengthSize = 4
+
+	// packet header, in bytes.
+	headerSize = 24
+
+	// UUID size, in bytes.
+	uuidSize = 16
+)
+
+// header is a libvirt rpc packet header
+type header struct {
+	// Program identifier
+	Program uint32
+
+	// Program version
+	Version uint32
+
+	// Remote procedure identifier
+	Procedure uint32
+
+	// Call type, e.g., Reply
+	Type uint32
+
+	// Call serial number
+	Serial uint32
+
+	// Request status, e.g., StatusOK
+	Status uint32
+}
+
+// packet represents a RPC request or response.
+type packet struct {
+	// Size of packet, in bytes, including length.
+	// Len + Header + Payload
+	Len    uint32
+	Header header
+}
+
+// libvirt's domain response type
+type domain struct {
+	Name string
+	UUID [uuidSize]byte
+	ID   int
+}
+
+// libvirt domain event
+type event struct {
+	CallbackID   uint32
+	Domain       domain
+	Event        string
+	Seconds      uint64
+	Microseconds uint32
+	Padding      uint8
+	Details      []byte
+}
+
+// internal rpc response
+type response struct {
+	Payload []byte
+	Status  uint32
+}
+
+// Monitor implements LibVirt's remote procedure call protocol.
+type Monitor struct {
+	// Domain name as seen by libvirt, e.g., stage-lb-1
+	Domain string
+
+	conn net.Conn
+	r    *bufio.Reader
+	w    *bufio.Writer
+
+	// method callbacks
+	cm        sync.Mutex
+	callbacks map[uint32]chan response
+
+	// event listeners
+	em     sync.Mutex
+	events map[uint32]chan *event
+
+	// next request serial number
+	s uint32
+}
+
+// New configures a new RPC Monitor connection.
+// The provided domain should be the name of the domain as seen
+// by libvirt, e.g., stage-lb-1.
+func New(domain string, conn net.Conn) *Monitor {
+	l := &Monitor{
+		Domain:    domain,
+		conn:      conn,
+		s:         0,
+		r:         bufio.NewReader(conn),
+		w:         bufio.NewWriter(conn),
+		callbacks: make(map[uint32]chan response),
+		events:    make(map[uint32]chan *event),
+	}
+
+	go l.listen()
+
+	return l
+}
+
+// listen processes incoming data and routes the
+// decoded responses to their respective handler.
+func (rpc *Monitor) listen() {
+	for {
+		// response packet length
+		length, err := pktlen(rpc.r)
+		if err != nil {
+			if err == io.EOF {
+				return
+			}
+
+			// invalid packet
+			continue
+		}
+
+		// response header
+		h, err := extractHeader(rpc.r)
+		if err != nil {
+			// invalid packet
+			continue
+		}
+
+		// payload: packet length minus what was previously read
+		size := int(length) - (packetLengthSize + headerSize)
+		buf := make([]byte, size)
+		for n := 0; n < size; {
+			nn, err := rpc.r.Read(buf)
+			if err != nil {
+				// invalid packet
+				continue
+			}
+
+			n += nn
+		}
+
+		// route response to caller
+		rpc.route(h, buf)
+	}
+}
+
+// Connect establishes communication with the libvirt server.
+// The underlying libvirt socket connection must be previously established.
+func (rpc *Monitor) Connect() error {
+	payload := struct {
+		Padding [3]byte
+		Name    string
+		Flags   uint32
+	}{
+		// This is what came of a stupid amount of tcpdump.
+		// Why this is needed remains a mystery.
+		Padding: [3]byte{0x1, 0x0, 0x0},
+		Name:    "qemu:///system",
+		Flags:   0,
+	}
+
+	buf, err := encode(&payload)
+	if err != nil {
+		return err
+	}
+
+	resp, err := rpc.request(procConnectOpen, programRemote, &buf)
+	if err != nil {
+		return err
+	}
+
+	r := <-resp
+	if r.Status != StatusOK {
+		return decodeError(r.Payload)
+	}
+
+	return nil
+}
+
+// Disconnect shuts down communication with the libvirt server.
+// The underlying net.Conn is not closed.
+func (rpc *Monitor) Disconnect() error {
+	// close event streams
+	for id := range rpc.events {
+		if err := rpc.removeStream(id); err != nil {
+			return err
+		}
+	}
+
+	// inform libvirt we're done
+	resp, err := rpc.request(procConnectClose, programRemote, nil)
+	if err != nil {
+		return err
+	}
+
+	r := <-resp
+	if r.Status != StatusOK {
+		return decodeError(r.Payload)
+	}
+
+	return nil
+}
+
+// Events streams QEMU QMP Events.
+// If a problem is encountered setting up the event monitor connection
+// an error will be returned. Errors encountered during streaming will
+// cause the returned event channel to be closed.
+func (rpc *Monitor) Events() (<-chan qmp.Event, error) {
+	d, err := rpc.lookup(rpc.Domain)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := struct {
+		Padding [4]byte
+		Domain  domain
+		Event   [2]byte
+		Flags   [2]byte
+	}{
+		Padding: [4]byte{0x0, 0x0, 0x1, 0x0},
+		Domain:  *d,
+		Event:   [2]byte{0x0, 0x0},
+		Flags:   [2]byte{0x0, 0x0},
+	}
+
+	buf, err := encode(&payload)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := rpc.request(qemuConnectDomainMonitorEventRegister, programQEMU, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	res := <-resp
+	dec := xdr.NewDecoder(bytes.NewReader(res.Payload))
+
+	cbID, _, err := dec.DecodeUint()
+	if err != nil {
+		return nil, err
+	}
+
+	c := make(chan qmp.Event)
+	go func() {
+		stream := make(chan *event)
+		rpc.addStream(cbID, stream)
+
+		// process events
+		for e := range stream {
+			qe, err := qmpEvent(e)
+			if err != nil {
+				close(c)
+				break
+			}
+
+			c <- *qe
+		}
+	}()
+
+	return c, nil
+}
+
+// Run executes the given QAPI command against a domain's QEMU instance.
+// For a list of available QAPI commands, see:
+//	http://git.qemu.org/?p=qemu.git;a=blob;f=qapi-schema.json;hb=HEAD
+func (rpc *Monitor) Run(cmd []byte) ([]byte, error) {
+	d, err := rpc.lookup(rpc.Domain)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := struct {
+		Domain  domain
+		Command []byte
+		Flags   uint32
+	}{
+		Domain:  *d,
+		Command: cmd,
+		Flags:   0,
+	}
+
+	buf, err := encode(&payload)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := rpc.request(qemuDomainMonitor, programQEMU, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	res := <-resp
+	if res.Status != StatusOK {
+		return nil, decodeError(res.Payload)
+	}
+
+	r := bytes.NewReader(res.Payload)
+	dec := xdr.NewDecoder(r)
+	data, _, err := dec.DecodeFixedOpaque(int32(r.Len()))
+	if err != nil {
+		return nil, err
+	}
+
+	// drop QMP control characters from start and end of line
+	return data[4 : len(data)-1], err
+}
+
+// callback sends rpc responses to their respective caller.
+func (rpc *Monitor) callback(id uint32, res response) {
+	c, ok := rpc.callbacks[id]
+	if ok {
+		c <- res
+	}
+
+	rpc.deregister(id)
+}
+
+// route sends incoming packets to their listeners.
+func (rpc *Monitor) route(h *header, buf []byte) {
+	// route events to their respective listener
+	if h.Program == programQEMU && h.Procedure == qemuDomainMonitorEvent {
+		rpc.stream(buf)
+		return
+	}
+
+	// send responses to caller
+	res := response{
+		Payload: buf,
+		Status:  h.Status,
+	}
+	rpc.callback(h.Serial, res)
+}
+
+// serial provides atomic access to the next sequential request serial number.
+func (rpc *Monitor) serial() uint32 {
+	return atomic.AddUint32(&rpc.s, 1)
+}
+
+// stream decodes domain events and sends them
+// to the respective event listener.
+func (rpc *Monitor) stream(buf []byte) {
+	e, err := decodeEvent(buf)
+	if err != nil {
+		// event was malformed, drop.
+		return
+	}
+
+	// send to event listener
+	if c, ok := rpc.events[e.CallbackID]; ok {
+		c <- e
+	}
+}
+
+// addStream configures the routing for an event stream.
+func (rpc *Monitor) addStream(id uint32, stream chan *event) {
+	rpc.em.Lock()
+	rpc.events[id] = stream
+	rpc.em.Unlock()
+}
+
+// removeStream notifies the libvirt server to stop sending events
+// for the provided callback id. Upon successful de-registration the
+// callback handler is destroyed.
+func (rpc *Monitor) removeStream(id uint32) error {
+	close(rpc.events[id])
+
+	payload := struct {
+		CallbackID uint32
+	}{
+		CallbackID: id,
+	}
+
+	buf, err := encode(&payload)
+	if err != nil {
+		return err
+	}
+
+	resp, err := rpc.request(qemuConnectDomainMonitorEventDeregister, programQEMU, &buf)
+	if err != nil {
+		return err
+	}
+
+	res := <-resp
+	if res.Status != StatusOK {
+		return decodeError(res.Payload)
+	}
+
+	rpc.em.Lock()
+	delete(rpc.events, id)
+	rpc.em.Unlock()
+
+	return nil
+}
+
+// register configures a method response callback
+func (rpc *Monitor) register(id uint32, c chan response) {
+	rpc.cm.Lock()
+	rpc.callbacks[id] = c
+	rpc.cm.Unlock()
+}
+
+// deregister destroys a method response callback
+func (rpc *Monitor) deregister(id uint32) {
+	close(rpc.callbacks[id])
+
+	rpc.cm.Lock()
+	delete(rpc.callbacks, id)
+	rpc.cm.Unlock()
+}
+
+// request performs a libvirt RPC request.
+// The returned channel is used by the caller to receive the asynchronous
+// call response. The channel is closed once a response has been sent.
+func (rpc *Monitor) request(proc uint32, program uint32, payload *bytes.Buffer) (<-chan response, error) {
+	serial := rpc.serial()
+	c := make(chan response)
+
+	rpc.register(serial, c)
+
+	size := packetLengthSize + headerSize
+	if payload != nil {
+		size += payload.Len()
+	}
+
+	p := packet{
+		Len: uint32(size),
+		Header: header{
+			Program:   program,
+			Version:   programVersion,
+			Procedure: proc,
+			Type:      Call,
+			Serial:    serial,
+			Status:    StatusOK,
+		},
+	}
+
+	// write header
+	err := binary.Write(rpc.w, binary.BigEndian, p)
+	if err != nil {
+		return nil, err
+	}
+
+	// write payload
+	if payload != nil {
+		err = binary.Write(rpc.w, binary.BigEndian, payload.Bytes())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := rpc.w.Flush(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// lookup returns a domain as seen by libvirt.
+func (rpc *Monitor) lookup(name string) (*domain, error) {
+	payload := struct {
+		Name string
+	}{name}
+
+	buf, err := encode(&payload)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := rpc.request(procDomainLookupByName, programRemote, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	r := <-resp
+	if r.Status != StatusOK {
+		return nil, decodeError(r.Payload)
+	}
+
+	dec := xdr.NewDecoder(bytes.NewReader(r.Payload))
+
+	var d domain
+	_, err = dec.Decode(&d)
+	if err != nil {
+		return nil, err
+	}
+
+	return &d, nil
+}
+
+// encode XDR encodes the provided data.
+func encode(data interface{}) (bytes.Buffer, error) {
+	var buf bytes.Buffer
+	_, err := xdr.Marshal(&buf, data)
+
+	return buf, err
+}
+
+// decodeError extracts an error message from the provider buffer.
+func decodeError(buf []byte) error {
+	dec := xdr.NewDecoder(bytes.NewReader(buf))
+	msg, _, err := dec.DecodeString()
+	if err != nil {
+		return err
+	}
+
+	return errors.New(msg)
+}
+
+// decodeEvent extracts an event from the given byte slice.
+// Errors encountered will be returned along with a nil event.
+func decodeEvent(buf []byte) (*event, error) {
+	var e event
+
+	dec := xdr.NewDecoder(bytes.NewReader(buf))
+	_, err := dec.Decode(&e)
+	if err != nil {
+		return nil, err
+	}
+
+	return &e, nil
+}
+
+// pktlen determines the length of an incoming rpc response.
+// If an error is encountered reading the provided Reader, the
+// error is returned and response length will be 0.
+func pktlen(r io.Reader) (uint32, error) {
+	buf := make([]byte, packetLengthSize)
+
+	for n := 0; n < cap(buf); {
+		nn, err := r.Read(buf)
+		if err != nil {
+			return 0, err
+		}
+
+		n += nn
+	}
+
+	return binary.BigEndian.Uint32(buf), nil
+}
+
+// extractHeader returns the decoded header from an incoming response.
+func extractHeader(r io.Reader) (*header, error) {
+	buf := make([]byte, headerSize)
+
+	for n := 0; n < cap(buf); {
+		nn, err := r.Read(buf)
+		if err != nil {
+			return nil, err
+		}
+
+		n += nn
+	}
+
+	h := &header{
+		Program:   binary.BigEndian.Uint32(buf[0:4]),
+		Version:   binary.BigEndian.Uint32(buf[4:8]),
+		Procedure: binary.BigEndian.Uint32(buf[8:12]),
+		Type:      binary.BigEndian.Uint32(buf[12:16]),
+		Serial:    binary.BigEndian.Uint32(buf[16:20]),
+		Status:    binary.BigEndian.Uint32(buf[20:24]),
+	}
+
+	return h, nil
+}
+
+// qmpEvent takes a libvirt event structure and returns the qmp equivalent.
+func qmpEvent(e *event) (*qmp.Event, error) {
+	var qe qmp.Event
+
+	if e.Details != nil {
+		if err := json.Unmarshal(e.Details, &qe.Data); err != nil {
+			return nil, err
+		}
+	}
+
+	qe.Event = e.Event
+	qe.Timestamp.Seconds = int64(e.Seconds)
+	qe.Timestamp.Microseconds = int64(e.Microseconds)
+
+	return &qe, nil
+}

--- a/qmp/libvirtrpc/rpc_test.go
+++ b/qmp/libvirtrpc/rpc_test.go
@@ -1,0 +1,620 @@
+// Copyright 2016 The go-qemu Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package libvirtrpc is a pure Go implementation of the libvirt RPC protocol.
+// For more information on the protocol, see https://libvirt.org/internals/rpc.html
+package libvirtrpc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"log"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-xdr/xdr2"
+	"github.com/digitalocean/go-qemu/qmp"
+)
+
+var (
+	// dc229f87d4de47198cfd2e21c6105b01
+	testUUID = [uuidSize]byte{
+		0xdc, 0x22, 0x9f, 0x87, 0xd4, 0xde, 0x47, 0x19,
+		0x8c, 0xfd, 0x2e, 0x21, 0xc6, 0x10, 0x5b, 0x01,
+	}
+)
+
+var testHeader = []byte{
+	0x20, 0x00, 0x80, 0x86, // program
+	0x00, 0x00, 0x00, 0x01, // version
+	0x00, 0x00, 0x00, 0x01, // procedure
+	0x00, 0x00, 0x00, 0x00, // type
+	0x00, 0x00, 0x00, 0x01, // serial
+	0x00, 0x00, 0x00, 0x00, // status
+}
+
+var testEventHeader = []byte{
+	0x00, 0x00, 0x00, 0xb0, // length
+	0x20, 0x00, 0x80, 0x87, // program
+	0x00, 0x00, 0x00, 0x01, // version
+	0x00, 0x00, 0x00, 0x06, // procedure
+	0x00, 0x00, 0x00, 0x01, // type
+	0x00, 0x00, 0x00, 0x02, // serial
+	0x00, 0x00, 0x00, 0x00, // status
+}
+
+var testEvent = []byte{
+	0x00, 0x00, 0x00, 0x01, // callback id
+
+	// domain name ("test")
+	0x00, 0x00, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74,
+
+	// uuid (dc229f87d4de47198cfd2e21c6105b01)
+	0xdc, 0x22, 0x9f, 0x87, 0xd4, 0xde, 0x47, 0x19,
+	0x8c, 0xfd, 0x2e, 0x21, 0xc6, 0x10, 0x5b, 0x01,
+
+	// domain id (14)
+	0x00, 0x00, 0x00, 0x0e,
+
+	// event name (BLOCK_JOB_COMPLETED)
+	0x00, 0x00, 0x00, 0x13, 0x42, 0x4c, 0x4f, 0x43,
+	0x4b, 0x5f, 0x4a, 0x4f, 0x42, 0x5f, 0x43, 0x4f,
+	0x4d, 0x50, 0x4c, 0x45, 0x54, 0x45, 0x44, 0x00,
+
+	// seconds (1462211891)
+	0x00, 0x00, 0x00, 0x00, 0x57, 0x27, 0x95, 0x33,
+
+	// microseconds (931791)
+	0x00, 0x0e, 0x37, 0xcf,
+
+	// event json data
+	// ({"device":"drive-ide0-0-0","len":0,"offset":0,"speed":0,"type":"commit"})
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x48,
+	0x7b, 0x22, 0x64, 0x65, 0x76, 0x69, 0x63, 0x65,
+	0x22, 0x3a, 0x22, 0x64, 0x72, 0x69, 0x76, 0x65,
+	0x2d, 0x69, 0x64, 0x65, 0x30, 0x2d, 0x30, 0x2d,
+	0x30, 0x22, 0x2c, 0x22, 0x6c, 0x65, 0x6e, 0x22,
+	0x3a, 0x30, 0x2c, 0x22, 0x6f, 0x66, 0x66, 0x73,
+	0x65, 0x74, 0x22, 0x3a, 0x30, 0x2c, 0x22, 0x73,
+	0x70, 0x65, 0x65, 0x64, 0x22, 0x3a, 0x30, 0x2c,
+	0x22, 0x74, 0x79, 0x70, 0x65, 0x22, 0x3a, 0x22,
+	0x63, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x22, 0x7d,
+}
+
+var testDomainResponse = []byte{
+	0x00, 0x00, 0x00, 0x38, // length
+	0x20, 0x00, 0x80, 0x86, // program
+	0x00, 0x00, 0x00, 0x01, // version
+	0x00, 0x00, 0x00, 0x17, // procedure
+	0x00, 0x00, 0x00, 0x01, // type
+	0x00, 0x00, 0x00, 0x01, // serial
+	0x00, 0x00, 0x00, 0x00, // status
+
+	// domain name ("test")
+	0x00, 0x00, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74,
+
+	// uuid (dc229f87d4de47198cfd2e21c6105b01)
+	0xdc, 0x22, 0x9f, 0x87, 0xd4, 0xde, 0x47, 0x19,
+	0x8c, 0xfd, 0x2e, 0x21, 0xc6, 0x10, 0x5b, 0x01,
+
+	// domain id (14)
+	0x00, 0x00, 0x00, 0x0e,
+}
+
+var testRegisterEvent = []byte{
+	0x00, 0x00, 0x00, 0x20, // length
+	0x20, 0x00, 0x80, 0x87, // program
+	0x00, 0x00, 0x00, 0x01, // version
+	0x00, 0x00, 0x00, 0x04, // procedure
+	0x00, 0x00, 0x00, 0x01, // type
+	0x00, 0x00, 0x00, 0x02, // serial
+	0x00, 0x00, 0x00, 0x00, // status
+	0x00, 0x00, 0x00, 0x01, // callback id
+}
+
+var testDeregisterEvent = []byte{
+	0x00, 0x00, 0x00, 0x1c, // length
+	0x20, 0x00, 0x80, 0x87, // program
+	0x00, 0x00, 0x00, 0x01, // version
+	0x00, 0x00, 0x00, 0x05, // procedure
+	0x00, 0x00, 0x00, 0x01, // type
+	0x00, 0x00, 0x00, 0x01, // serial
+	0x00, 0x00, 0x00, 0x00, // status
+}
+
+var testConnectReply = []byte{
+	0x00, 0x00, 0x00, 0x1c, // length
+	0x20, 0x00, 0x80, 0x86, // program
+	0x00, 0x00, 0x00, 0x01, // version
+	0x00, 0x00, 0x00, 0x01, // procedure
+	0x00, 0x00, 0x00, 0x01, // type
+	0x00, 0x00, 0x00, 0x01, // serial
+	0x00, 0x00, 0x00, 0x00, // status
+}
+
+var testDisconnectReply = []byte{
+	0x00, 0x00, 0x00, 0x1c, // length
+	0x20, 0x00, 0x80, 0x86, // program
+	0x00, 0x00, 0x00, 0x01, // version
+	0x00, 0x00, 0x00, 0x02, // procedure
+	0x00, 0x00, 0x00, 0x01, // type
+	0x00, 0x00, 0x00, 0x01, // serial
+	0x00, 0x00, 0x00, 0x00, // status
+}
+
+var testRunReply = []byte{
+	0x00, 0x00, 0x00, 0x74, // length
+	0x20, 0x00, 0x80, 0x87, // program
+	0x00, 0x00, 0x00, 0x01, // version
+	0x00, 0x00, 0x00, 0x01, // procedure
+	0x00, 0x00, 0x00, 0x01, // type
+	0x00, 0x00, 0x00, 0x02, // serial
+	0x00, 0x00, 0x00, 0x00, // status
+
+	// {"return":{"qemu":{"micro":92,"minor":5,"major":2},"package":""},"id":"libvirt-84"}
+	0x00, 0x00, 0x00, 0x53, 0x7b, 0x22, 0x72, 0x65,
+	0x74, 0x75, 0x72, 0x6e, 0x22, 0x3a, 0x7b, 0x22,
+	0x71, 0x65, 0x6d, 0x75, 0x22, 0x3a, 0x7b, 0x22,
+	0x6d, 0x69, 0x63, 0x72, 0x6f, 0x22, 0x3a, 0x39,
+	0x32, 0x2c, 0x22, 0x6d, 0x69, 0x6e, 0x6f, 0x72,
+	0x22, 0x3a, 0x35, 0x2c, 0x22, 0x6d, 0x61, 0x6a,
+	0x6f, 0x72, 0x22, 0x3a, 0x32, 0x7d, 0x2c, 0x22,
+	0x70, 0x61, 0x63, 0x6b, 0x61, 0x67, 0x65, 0x22,
+	0x3a, 0x22, 0x22, 0x7d, 0x2c, 0x22, 0x69, 0x64,
+	0x22, 0x3a, 0x22, 0x6c, 0x69, 0x62, 0x76, 0x69,
+	0x72, 0x74, 0x2d, 0x38, 0x34, 0x22, 0x7d, 0x00,
+}
+
+var testDomain = domain{
+	Name: "test-domain",
+	UUID: testUUID,
+	ID:   1,
+}
+
+type mockLibvirt struct {
+	net.Conn
+	test net.Conn
+}
+
+func setupTest(t *testing.T) *mockLibvirt {
+	serv, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := net.Dial("tcp", serv.Addr().String())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	m := &mockLibvirt{Conn: conn}
+
+	go func() {
+		for {
+			conn, _ := serv.Accept()
+			m.test = conn
+			go m.handle(m.test)
+		}
+	}()
+
+	return m
+}
+
+func (m *mockLibvirt) handle(conn net.Conn) {
+	for {
+		buf := make([]byte, packetLengthSize+headerSize)
+		conn.Read(buf)
+
+		// extract program
+		prog := binary.BigEndian.Uint32(buf[4:8])
+
+		// extract procedure
+		proc := binary.BigEndian.Uint32(buf[12:16])
+
+		switch prog {
+		case programRemote:
+			switch proc {
+			case procConnectOpen:
+				conn.Write(testConnectReply)
+			case procConnectClose:
+				conn.Write(testDisconnectReply)
+			case procDomainLookupByName:
+				conn.Write(testDomainResponse)
+			}
+		case programQEMU:
+			switch proc {
+			case qemuConnectDomainMonitorEventRegister:
+				conn.Write(testRegisterEvent)
+			case qemuConnectDomainMonitorEventDeregister:
+				conn.Write(testDeregisterEvent)
+			case qemuDomainMonitor:
+				conn.Write(testRunReply)
+			}
+		}
+	}
+}
+
+func TestNew(t *testing.T) {
+	domain := "test-1"
+
+	conn := setupTest(t)
+	rpc := New(domain, conn)
+
+	if rpc.Domain != domain {
+		t.Errorf("expected domain %q, got %q", domain, rpc.Domain)
+	}
+}
+
+func TestQMPEvent(t *testing.T) {
+	e := &event{
+		CallbackID:   1,
+		Domain:       testDomain,
+		Event:        "test",
+		Seconds:      1,
+		Microseconds: 1,
+		Details:      []byte(`{"device":"drive-virtio-disk0","len":0,"offset":0,"speed":0,"type":"commit"}`),
+	}
+
+	qe, err := qmpEvent(e)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if qe.Event != e.Event {
+		t.Errorf("expected event %q, got %q", e.Event, qe.Event)
+	}
+
+	if qe.Timestamp.Seconds != int64(e.Seconds) {
+		t.Errorf("expected seconds to be %q, got %q", e.Seconds, qe.Timestamp.Seconds)
+	}
+
+	if qe.Timestamp.Microseconds != int64(e.Microseconds) {
+		t.Errorf("expected microseconds to be %q, got %q", e.Microseconds, qe.Timestamp.Microseconds)
+	}
+
+	expected := "drive-virtio-disk0"
+	actual, ok := qe.Data["device"]
+	if !ok {
+		t.Error("expected event data 'device'")
+	}
+
+	if actual != expected {
+		t.Errorf("expected device %q, got %q", expected, actual)
+	}
+}
+
+func TestExtractHeader(t *testing.T) {
+	r := bytes.NewBuffer(testHeader)
+	h, err := extractHeader(r)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if h.Program != programRemote {
+		t.Errorf("expected Program %q, got %q", programRemote, h.Program)
+	}
+
+	if h.Version != programVersion {
+		t.Errorf("expected version %q, got %q", programVersion, h.Version)
+	}
+
+	if h.Procedure != procConnectOpen {
+		t.Errorf("expected procedure %q, got %q", procConnectOpen, h.Procedure)
+	}
+
+	if h.Type != Call {
+		t.Errorf("expected type %q, got %q", Call, h.Type)
+	}
+
+	if h.Status != StatusOK {
+		t.Errorf("expected status %q, got %q", StatusOK, h.Status)
+	}
+}
+
+func TestPktLen(t *testing.T) {
+	data := []byte{0x00, 0x00, 0x00, 0xa} // uint32:10
+	r := bytes.NewBuffer(data)
+
+	expected := uint32(10)
+	actual, err := pktlen(r)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if expected != actual {
+		t.Errorf("expected packet length %q, got %q", expected, actual)
+	}
+}
+
+func TestDecodeEvent(t *testing.T) {
+	e, err := decodeEvent(testEvent)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expCbID := uint32(1)
+	if e.CallbackID != expCbID {
+		t.Errorf("expected callback id %d, got %d", expCbID, e.CallbackID)
+	}
+
+	expName := "test"
+	if e.Domain.Name != expName {
+		t.Errorf("expected domain %s, got %s", expName, e.Domain.Name)
+	}
+
+	expUUID := testUUID
+	if !bytes.Equal(e.Domain.UUID[:], expUUID[:]) {
+		t.Errorf("expected uuid:\t%x, got\n\t\t\t%x", expUUID, e.Domain.UUID)
+	}
+
+	expID := 14
+	if e.Domain.ID != expID {
+		t.Errorf("expected id %d, got %d", expID, e.Domain.ID)
+	}
+
+	expEvent := "BLOCK_JOB_COMPLETED"
+	if e.Event != expEvent {
+		t.Errorf("expected %s, got %s", expEvent, e.Event)
+	}
+
+	expSec := uint64(1462211891)
+	if e.Seconds != expSec {
+		t.Errorf("expected seconds to be %d, got %d", expSec, e.Seconds)
+	}
+
+	expMs := uint32(931791)
+	if e.Microseconds != expMs {
+		t.Errorf("expected microseconds to be %d, got %d", expMs, e.Microseconds)
+	}
+
+	expDetails := []byte(`{"device":"drive-ide0-0-0","len":0,"offset":0,"speed":0,"type":"commit"}`)
+	if e.Domain.ID != expID {
+		t.Errorf("expected data %s, got %s", expDetails, e.Details)
+	}
+}
+
+func TestDecodeError(t *testing.T) {
+	msg := "foo"
+	buf := bytes.NewBuffer(nil)
+	enc := xdr.NewEncoder(buf)
+
+	_, err := enc.EncodeString(msg)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = decodeError(buf.Bytes())
+	if err.Error() != msg {
+		t.Errorf("expected error %s, got %s", msg, err.Error())
+	}
+}
+
+func TestEncode(t *testing.T) {
+	data := "test"
+	buf, err := encode(data)
+	if err != nil {
+		t.Error(err)
+	}
+
+	dec := xdr.NewDecoder(bytes.NewReader(buf.Bytes()))
+	res, _, err := dec.DecodeString()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if res != data {
+		t.Errorf("expected %s, got %s", data, res)
+	}
+}
+
+func TestRegister(t *testing.T) {
+	rpc := &Monitor{}
+	rpc.callbacks = make(map[uint32]chan response)
+	id := uint32(1)
+	c := make(chan response)
+
+	rpc.register(id, c)
+	if _, ok := rpc.callbacks[id]; !ok {
+		t.Error("expected callback to register")
+	}
+}
+
+func TestDeregister(t *testing.T) {
+	id := uint32(1)
+
+	rpc := &Monitor{}
+	rpc.callbacks = map[uint32]chan response{
+		id: make(chan response),
+	}
+
+	rpc.deregister(id)
+	if _, ok := rpc.callbacks[id]; ok {
+		t.Error("expected callback to deregister")
+	}
+}
+
+func TestAddStream(t *testing.T) {
+	id := uint32(1)
+	c := make(chan *event)
+
+	rpc := &Monitor{}
+	rpc.events = make(map[uint32]chan *event)
+
+	rpc.addStream(id, c)
+	if _, ok := rpc.events[id]; !ok {
+		t.Error("expected event stream to exist")
+	}
+}
+
+func TestRemoveStream(t *testing.T) {
+	id := uint32(1)
+
+	conn := setupTest(t)
+	rpc := New("test", conn)
+	rpc.events[id] = make(chan *event)
+
+	err := rpc.removeStream(id)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if _, ok := rpc.events[id]; ok {
+		t.Error("expected event stream to be removed")
+	}
+}
+
+func TestStream(t *testing.T) {
+	id := uint32(1)
+	c := make(chan *event, 1)
+
+	rpc := &Monitor{}
+	rpc.events = map[uint32]chan *event{
+		id: c,
+	}
+
+	rpc.stream(testEvent)
+	e := <-c
+
+	if e.Event != "BLOCK_JOB_COMPLETED" {
+		t.Error("expected event")
+	}
+}
+
+func TestSerial(t *testing.T) {
+	count := uint32(10)
+	rpc := &Monitor{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			rpc.serial()
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	expected := count + uint32(1)
+	actual := rpc.serial()
+	if expected != actual {
+		t.Errorf("expected serial to be %d, got %d", expected, actual)
+	}
+}
+
+func TestLookup(t *testing.T) {
+	id := uint32(1)
+	c := make(chan response)
+	name := "test"
+
+	conn := setupTest(t)
+	rpc := New(name, conn)
+
+	rpc.register(id, c)
+
+	d, err := rpc.lookup(name)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if d == nil {
+		t.Error("nil domain returned")
+	}
+
+	if d.Name != name {
+		t.Errorf("expected domain %s, got %s", name, d.Name)
+	}
+}
+
+func TestConnect(t *testing.T) {
+	conn := setupTest(t)
+	rpc := New("test", conn)
+
+	err := rpc.Connect()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDisconnect(t *testing.T) {
+	conn := setupTest(t)
+	rpc := New("test", conn)
+
+	err := rpc.Disconnect()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRun(t *testing.T) {
+	conn := setupTest(t)
+	rpc := New("test", conn)
+
+	res, err := rpc.Run([]byte(`{"query-version"}`))
+	if err != nil {
+		t.Error(err)
+	}
+
+	type version struct {
+		Return struct {
+			Package string `json:"package"`
+			QEMU    struct {
+				Major int `json:"major"`
+				Micro int `json:"micro"`
+				Minor int `json:"minor"`
+			} `json:"qemu"`
+		} `json:"return"`
+	}
+
+	var v version
+	err = json.Unmarshal(res, &v)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := 2
+	if v.Return.QEMU.Major != expected {
+		t.Errorf("expected qemu major version %d, got %d", expected, v.Return.QEMU.Major)
+	}
+}
+
+func TestEvents(t *testing.T) {
+	conn := setupTest(t)
+	rpc := New("test", conn)
+
+	stream, err := rpc.Events()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// send an event
+	go func() {
+		conn.test.Write(append(testEventHeader, testEvent...))
+	}()
+
+	var e qmp.Event
+	select {
+	case e = <-stream:
+	case <-time.After(time.Second * 1):
+		t.Error("expected event, received timeout")
+	}
+
+	expected := "drive-ide0-0-0"
+	if e.Data["device"] != expected {
+		t.Errorf("expected device %q, got %q", expected, e.Data["device"])
+	}
+}


### PR DESCRIPTION
This adds a new QMP monitor that makes use of libvirt's RPC protocol.

resources:
- https://libvirt.org/internals/rpc.html
- https://www.berrange.com/posts/2011/11/30/watching-the-libvirt-rpc-protocol-using-systemtap/
- libvirt source:
    - src/remote/remote_protocol.x
- wireshark libvirt dissector
    - libvirt: `./configure --with-wireshark-dissector ...`

TODO:
- Connection keep-alive (PING/PONG) while event monitor is active

A note on testing:

I've tried to emulate the exact responses as sent by libvirt, hence the raw bytes. This could be clarified by XDR encoding predefined types. However, I've seen small inconsistencies between the encoding provided by our XDR package and libvirt. This method should ensure we're always testing against known-good data as sent by libvirt.

fixes #9 