### PR TITLE
hypervisor: adds hypervisor Driver for RPC

### DIFF
--- a/hypervisor/rpc.go
+++ b/hypervisor/rpc.go
@@ -1,0 +1,52 @@
+// Copyright 2016 The go-qemu Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hypervisor
+
+import (
+	"net"
+
+	"github.com/digitalocean/go-qemu/qmp"
+	"github.com/digitalocean/go-qemu/qmp/libvirtrpc"
+)
+
+var _ Driver = &RPCDriver{}
+
+// RPCDriver is a QEMU QMP monitor driver which
+// communicates via libvirt's RPC interface.
+type RPCDriver struct {
+	h       *libvirtrpc.Hypervisor
+	newConn func() (net.Conn, error)
+}
+
+// NewMonitor creates a new qmp.Monitor using libvirt RPC.
+func (d *RPCDriver) NewMonitor(domain string) (qmp.Monitor, error) {
+	conn, err := d.newConn()
+	return libvirtrpc.New(domain, conn), err
+}
+
+// DomainNames retrieves all hypervisor domain names using libvirt RPC.
+func (d *RPCDriver) DomainNames() ([]string, error) {
+	return d.h.DomainNames()
+}
+
+// NewLibvirtDriver configures a RPCDriver.
+// The provided newConn function should return an established
+// network connection with the target libvirt daemon.
+func NewRPCDriver(newConn func() (net.Conn, error)) *RPCDriver {
+	return &RPCDriver{
+		h:       libvirtrpc.NewHypervisor(newConn),
+		newConn: newConn,
+	}
+}

--- a/qmp/libvirtrpc/rpc.go
+++ b/qmp/libvirtrpc/rpc.go
@@ -304,8 +304,8 @@ func (rpc *Monitor) Connect() error {
 	return nil
 }
 
-// Disconnect shuts down communication with the libvirt server.
-// The underlying net.Conn is not closed.
+// Disconnect shuts down communication with the libvirt server
+// and closes the underlying net.Conn.
 func (rpc *Monitor) Disconnect() error {
 	// close event streams
 	for id := range rpc.events {
@@ -325,7 +325,7 @@ func (rpc *Monitor) Disconnect() error {
 		return decodeError(r.Payload)
 	}
 
-	return nil
+	return rpc.conn.Close()
 }
 
 // Events streams QEMU QMP Events.


### PR DESCRIPTION
This adds a new hypervisor Driver backed by libvirt RPC.

The most notable change here is that libvirtrpc.Disconnect() now closes the underlying net.Conn. I've included the change here in order to keep the driver relatively simple. However, we'll need to make this change either way. It turns out that when Disconnect() is called, libvirt closes its half of the connection. Not closing our half provides a confusing interface for the caller. If the connection were to be reused,
subsequent calls would fail with a TCP RST.

Fixes #42