### PR TITLE
libvirtrpc: check event stream result for errors

### DIFF
--- a/qmp/libvirtrpc/rpc.go
+++ b/qmp/libvirtrpc/rpc.go
@@ -361,6 +361,10 @@ func (rpc *Monitor) Events() (<-chan qmp.Event, error) {
 	}
 
 	res := <-resp
+	if res.Status != StatusOK {
+		return nil, decodeError(res.Payload)
+	}
+
 	dec := xdr.NewDecoder(bytes.NewReader(res.Payload))
 
 	cbID, _, err := dec.DecodeUint()


### PR DESCRIPTION
This fixes a bug in `Events()` that caused a panic when closing invalid event streams. The event monitor was failing to verify that event stream registration had successfully returned.