### PR TITLE
qmp: return ErrEventsUnsupported for old versions of libvirt

### DIFF
--- a/internal/shellexec/shellexec.go
+++ b/internal/shellexec/shellexec.go
@@ -60,6 +60,10 @@ type systemCommand struct {
 
 // Exited reports whether the command has exited.
 func (cmd *systemCommand) Exited() bool {
+	if cmd.Cmd.ProcessState == nil {
+		return true
+	}
+
 	return cmd.Cmd.ProcessState.Exited()
 }
 

--- a/qmp/libvirt.go
+++ b/qmp/libvirt.go
@@ -134,6 +134,12 @@ func (mon *Libvirt) Events() (<-chan Event, error) {
 		return nil, err
 	}
 
+	// older versions of libvirt do not support 'qemu-monitor-event'
+	if cmd.Exited() {
+		close(stream)
+		return nil, ErrEventsNotSupported
+	}
+
 	go func() {
 		<-mon.disconnect
 

--- a/qmp/qmp.go
+++ b/qmp/qmp.go
@@ -17,8 +17,13 @@
 package qmp
 
 import (
+	"errors"
 	"fmt"
 )
+
+// ErrEventsNotSupported is returned by Events() if event streams
+// are unsupported by either QEMU or libvirt.
+var ErrEventsNotSupported = errors.New("event monitor is not supported")
 
 // Monitor represents a QEMU Machine Protocol socket.
 // See: http://wiki.qemu.org/QMP


### PR DESCRIPTION
Older versions of libvirt do not have support for event monitoring. This modifies the RPC and shellout QMP drivers to return `ErrEventsUnsupported` when we've detected a lack of support. This required error inspection for the RPC driver and an unfortunate catch-all for early terminated shellout commands.