### PR TITLE
qemu: gracefully handle unsupported event monitor

### DIFF
--- a/block.go
+++ b/block.go
@@ -227,13 +227,17 @@ func (bd BlockDevice) Snapshot(d *Domain, overlay string) error {
 func waitForSignal(d *Domain, signal string, timeout time.Duration, fn func() error) error {
 	// "done" signal must be sent in both the error and non-error case, to
 	// avoid leaking goroutines.
-	events, done := d.Events()
-	if err := fn(); err != nil {
+	events, done, err := d.Events()
+	if err != nil {
+		return err
+	}
+
+	if err = fn(); err != nil {
 		done <- struct{}{}
 		return err
 	}
 
-	err := waitForJob(events, signal, timeout)
+	err = waitForJob(events, signal, timeout)
 	done <- struct{}{}
 	return err
 }

--- a/domain_test.go
+++ b/domain_test.go
@@ -463,3 +463,39 @@ func TestSupportedMonitorFailure(t *testing.T) {
 		t.Error("expected monitor failure")
 	}
 }
+
+func TestEvents(t *testing.T) {
+	m := &mockMonitor{}
+
+	d, err := NewDomain(m, "foo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	events, done, err := d.Events()
+	if err != nil {
+		t.Error(err)
+	}
+
+	select {
+	case <-events:
+		done <- struct{}{}
+	case <-time.After(time.Second * 2):
+		t.Error("expected event")
+	}
+}
+
+func TestEventsUnsupported(t *testing.T) {
+	m := &mockMonitor{}
+	m.eventsUnsupported = true
+
+	d, err := NewDomain(m, "foo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, _, err = d.Events()
+	if err != qmp.ErrEventsNotSupported {
+		t.Errorf("expected qmp.ErrEventsNotSupported, got %s", err.Error())
+	}
+}


### PR DESCRIPTION
This modifies `listenAndServe()` to set a flag on the domain when event streaming is unsupported. The caller will then receive `qmp.ErrEventsNotSupported` when calling `Domain.Events()`.
This allows `NewDomain()` to gracefully return given that not all users are interested in events.

Fixes #62 