### PR TITLE
Add ability to get version string from libvirt drivers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Matt Layher	<mlayher@digitalocean.com>
 
 Contributors
 ------------
+Justin Kim      <justin@digitalocean.com>

--- a/hypervisor/hypervisor.go
+++ b/hypervisor/hypervisor.go
@@ -49,6 +49,12 @@ type Driver interface {
 	DomainNames() ([]string, error)
 }
 
+// A Versioner is a Driver that is able to report its version on the
+// Hypervisor.
+type Versioner interface {
+	Version() (string, error)
+}
+
 // Domains retrieves all virtual machines which reside on a given hypervisor,
 // connecting to the monitor socket of each machine.
 //

--- a/hypervisor/libvirt.go
+++ b/hypervisor/libvirt.go
@@ -24,6 +24,7 @@ import (
 )
 
 var _ Driver = &LibvirtDriver{}
+var _ Versioner = &LibvirtDriver{}
 
 // A LibvirtDriver is a QEMU QMP monitor driver which utilizes libvirt by
 // shelling out to 'virsh'.
@@ -41,6 +42,21 @@ func (d *LibvirtDriver) NewMonitor(domain string) (qmp.Monitor, error) {
 // 'virsh'.
 func (d *LibvirtDriver) DomainNames() ([]string, error) {
 	return d.virshList()
+}
+
+// Version returns the version string for libvirt on the hypervisor.
+func (d *LibvirtDriver) Version() (string, error) {
+	out, err := virsh.Virsh(
+		d.prep,
+		d.uri.String(),
+		"--version",
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// Strip all newlines down to the version string
+	return strings.TrimSpace(string(out)), nil
 }
 
 // NewLibvirtDriver configures a LibvirtDriver using the provided hypervisor URI.

--- a/hypervisor/rpc.go
+++ b/hypervisor/rpc.go
@@ -22,6 +22,7 @@ import (
 )
 
 var _ Driver = &RPCDriver{}
+var _ Versioner = &RPCDriver{}
 
 // RPCDriver is a QEMU QMP monitor driver which
 // communicates via libvirt's RPC interface.
@@ -39,6 +40,11 @@ func (d *RPCDriver) NewMonitor(domain string) (qmp.Monitor, error) {
 // DomainNames retrieves all hypervisor domain names using libvirt RPC.
 func (d *RPCDriver) DomainNames() ([]string, error) {
 	return d.h.DomainNames()
+}
+
+// Version returns the version string for the libvirt daemon.
+func (d *RPCDriver) Version() (string, error) {
+	return d.h.Version()
 }
 
 // NewRPCDriver configures a RPCDriver.

--- a/qmp/libvirtrpc/hypervisor_test.go
+++ b/qmp/libvirtrpc/hypervisor_test.go
@@ -45,3 +45,17 @@ func TestDomainNames(t *testing.T) {
 		}
 	}
 }
+
+func TestVersion(t *testing.T) {
+	h := NewHypervisor(hvConn)
+
+	version, err := h.Version()
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := "1.3.4"
+	if version != expected {
+		t.Errorf("expected version %q, got %q", expected, version)
+	}
+}

--- a/qmp/libvirtrpc/mock_test.go
+++ b/qmp/libvirtrpc/mock_test.go
@@ -153,6 +153,17 @@ var testDomainsReply = []byte{
 	0x00, 0x00, 0x02,
 }
 
+var testLibVersionReply = []byte{
+	0x00, 0x00, 0x00, 0x24, // length
+	0x20, 0x00, 0x80, 0x86, // program
+	0x00, 0x00, 0x00, 0x01, // version
+	0x00, 0x00, 0x00, 0x9d, // procedure
+	0x00, 0x00, 0x00, 0x01, // type
+	0x00, 0x00, 0x00, 0x00, // serial
+	0x00, 0x00, 0x00, 0x00, // status
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x0f, 0x4d, 0xfc, // version (1003004)
+}
+
 type mockLibvirt struct {
 	net.Conn
 	test   net.Conn
@@ -200,6 +211,8 @@ func (m *mockLibvirt) handleRemote(procedure uint32, conn net.Conn) {
 		conn.Write(m.reply(testConnectReply))
 	case procConnectClose:
 		conn.Write(m.reply(testDisconnectReply))
+	case procConnectGetLibVersion:
+		conn.Write(m.reply(testLibVersionReply))
 	case procDomainLookupByName:
 		conn.Write(m.reply(testDomainResponse))
 	case procConnectListAllDomains:

--- a/qmp/libvirtrpc/rpc.go
+++ b/qmp/libvirtrpc/rpc.go
@@ -92,6 +92,7 @@ const (
 	procConnectClose          = 2
 	procDomainLookupByName    = 23
 	procAuthList              = 66
+	procConnectGetLibVersion  = 157
 	procConnectListAllDomains = 273
 )
 


### PR DESCRIPTION
This PR adds a Versioner interface to `hypervisor` and implements it for `LibvirtDriver` and `RPCDriver`.

cc @benlemasurier 