### PR TITLE
qemu, hypervisor: Domain always disconnects underlying qmp.Monitor

### DIFF
--- a/block_test.go
+++ b/block_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestBlockDevices(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -59,7 +59,7 @@ func TestBlockDevicesMonitorFail(t *testing.T) {
 }
 
 func TestBlockDevicesInvalidJSON(t *testing.T) {
-	m := mockMonitor{invalidJSON: true}
+	m := &mockMonitor{invalidJSON: true}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -73,7 +73,7 @@ func TestBlockDevicesInvalidJSON(t *testing.T) {
 }
 
 func TestCancelJob(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -112,7 +112,7 @@ func TestCancelJobMonitorFailure(t *testing.T) {
 }
 
 func TestCommit(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -189,7 +189,7 @@ func TestCommitTimeout(t *testing.T) {
 }
 
 func TestJobComplete(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -266,7 +266,7 @@ func TestJobCompleteTimeout(t *testing.T) {
 }
 
 func TestMirror(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -285,7 +285,7 @@ func TestMirror(t *testing.T) {
 }
 
 func TestMirrorRelativePath(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -325,7 +325,7 @@ func TestMirrorMonitorFailure(t *testing.T) {
 }
 
 func TestSnapshot(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {

--- a/domain.go
+++ b/domain.go
@@ -47,13 +47,12 @@ type Domain struct {
 	tempFileName func(domainName string, method string) string
 }
 
-// Close cleans up internal resources of a Domain.  Close must be called
-// when done with a Domain to avoid leaking resources.
-//
-// Close does not disconnect the underlying qmp.Monitor.
+// Close cleans up internal resources of a Domain and disconnects the underlying
+// qmp.Monitor.  Close must be called when done with a Domain to avoid leaking
+// resources.
 func (d *Domain) Close() error {
 	close(d.done)
-	return nil
+	return d.m.Disconnect()
 }
 
 // Commands returns all QMP commands supported by the domain.

--- a/domain_test.go
+++ b/domain_test.go
@@ -28,7 +28,7 @@ import (
 const defaultTestTimeout = 5 * time.Second
 
 func TestNew(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	_, err := NewDomain(m, "foo")
 	if err != nil {
@@ -37,7 +37,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewError(t *testing.T) {
-	m := mockMonitor{alwaysFail: true}
+	m := &mockMonitor{alwaysFail: true}
 
 	_, err := NewDomain(m, "foo")
 	if err == nil {
@@ -46,7 +46,7 @@ func TestNewError(t *testing.T) {
 }
 
 func TestBlockDevice(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -65,7 +65,7 @@ func TestBlockDevice(t *testing.T) {
 }
 
 func TestBlockDeviceNotFound(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -98,7 +98,7 @@ func TestBlockDeviceMonitorFailure(t *testing.T) {
 }
 
 func TestBlockJobs(t *testing.T) {
-	m := mockMonitor{activeJobs: true}
+	m := &mockMonitor{activeJobs: true}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -126,7 +126,7 @@ func TestBlockJobs(t *testing.T) {
 }
 
 func TestBlockStats(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -169,7 +169,7 @@ func TestBlockJobsMonitorFail(t *testing.T) {
 }
 
 func TestBlockJobsInvalidJSON(t *testing.T) {
-	m := mockMonitor{invalidJSON: true}
+	m := &mockMonitor{invalidJSON: true}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -183,7 +183,7 @@ func TestBlockJobsInvalidJSON(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -198,13 +198,13 @@ func TestClose(t *testing.T) {
 		t.Error("domain should be closed")
 	}
 
-	if err := m.Disconnect(); err != nil {
-		t.Error(err)
+	if !m.disconnected {
+		t.Error("monitor should be disconnected")
 	}
 }
 
 func TestCommands(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -251,7 +251,7 @@ func TestCommandsMonitorFailure(t *testing.T) {
 }
 
 func TestCommandsInvalidJSON(t *testing.T) {
-	m := mockMonitor{invalidJSON: true}
+	m := &mockMonitor{invalidJSON: true}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -264,7 +264,7 @@ func TestCommandsInvalidJSON(t *testing.T) {
 }
 
 func TestDomainScreenDump(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -306,7 +306,7 @@ func TestDomainScreenDump(t *testing.T) {
 }
 
 func TestPCIDevices(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -334,7 +334,7 @@ func TestPCIDevices(t *testing.T) {
 }
 
 func TestStatusRunning(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -352,7 +352,7 @@ func TestStatusRunning(t *testing.T) {
 }
 
 func TestStatusShutdown(t *testing.T) {
-	m := mockMonitor{poweredOff: true}
+	m := &mockMonitor{poweredOff: true}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -385,7 +385,7 @@ func TestStatusFail(t *testing.T) {
 }
 
 func TestStatusInvalidJSON(t *testing.T) {
-	m := mockMonitor{invalidJSON: true}
+	m := &mockMonitor{invalidJSON: true}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -399,7 +399,7 @@ func TestStatusInvalidJSON(t *testing.T) {
 }
 
 func TestRunInvalidCommand(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -413,7 +413,7 @@ func TestRunInvalidCommand(t *testing.T) {
 }
 
 func TestSupported(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -432,7 +432,7 @@ func TestSupported(t *testing.T) {
 }
 
 func TestSupportedFalse(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -465,7 +465,7 @@ func TestSupportedMonitorFailure(t *testing.T) {
 }
 
 func TestSystemPowerdown(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -478,7 +478,7 @@ func TestSystemPowerdown(t *testing.T) {
 }
 
 func TestSystemReset(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {

--- a/hypervisor/hypervisor_test.go
+++ b/hypervisor/hypervisor_test.go
@@ -53,11 +53,6 @@ func TestHypervisorDomains(t *testing.T) {
 		t.Fatalf("did not open monitors for all domains:\n- want: %v\n-  got: %v",
 			want, got)
 	}
-
-	if want, got := 3, len(hv.connected); want != got {
-		t.Fatalf("unexpected number of connected domains:\n- want: %v\n-  got: %v",
-			want, got)
-	}
 }
 
 func TestHypervisorDomainOK(t *testing.T) {
@@ -78,12 +73,6 @@ func TestHypervisorDomainOK(t *testing.T) {
 		t.Fatalf("unexpected domain:\n- want: %v\n-  got: %v",
 			want, got)
 	}
-
-	if want, got := 1, len(hv.connected); want != got {
-		t.Fatalf("unexpected number of connected domains:\n- want: %v\n-  got: %v",
-			want, got)
-	}
-
 }
 
 func TestHypervisorDomainNotFound(t *testing.T) {
@@ -116,51 +105,6 @@ func TestHypervisorDomainNames(t *testing.T) {
 
 	if want, got := wantDomains, gotDomains; !reflect.DeepEqual(want, got) {
 		t.Fatalf("unexpected domain names:\n- want: %v\n-  got: %v",
-			want, got)
-	}
-
-	if want, got := 0, len(hv.connected); want != got {
-		t.Fatalf("unexpected number of connected domains:\n- want: %v\n-  got: %v",
-			want, got)
-	}
-}
-
-func TestHypervisorDisconnect(t *testing.T) {
-	mon := &testConnectMonitor{}
-
-	hv := testHypervisor(
-		t,
-		[]string{"ubuntu"},
-		func(_ string) (qmp.Monitor, error) {
-			return mon, nil
-		},
-	)
-
-	if _, err := hv.Domains(); err != nil {
-		t.Fatalf("failed to connect domains: %v", err)
-	}
-
-	if want, got := 1, len(hv.connected); want != got {
-		t.Fatalf("unexpected number of connected domains:\n- want: %v\n-  got: %v",
-			want, got)
-	}
-
-	if want, got := true, mon.connected; want != got {
-		t.Fatalf("unexpected monitor connected value:\n- want: %v\n-  got: %v",
-			want, got)
-	}
-
-	if err := hv.Disconnect(); err != nil {
-		t.Fatalf("failed to disconnect Libvirt: %v", err)
-	}
-
-	if want, got := 0, len(hv.connected); want != got {
-		t.Fatalf("unexpected number of connected domains:\n- want: %v\n-  got: %v",
-			want, got)
-	}
-
-	if want, got := false, mon.connected; want != got {
-		t.Fatalf("unexpected monitor connected value:\n- want: %v\n-  got: %v",
 			want, got)
 	}
 }

--- a/mock_test.go
+++ b/mock_test.go
@@ -33,9 +33,10 @@ type mockMonitor struct {
 	invalidJSON       bool
 	poweredOff        bool
 	eventsUnsupported bool
+	disconnected      bool
 }
 
-func (mm mockMonitor) Connect() error {
+func (mm *mockMonitor) Connect() error {
 	if mm.alwaysFail {
 		return errors.New("fail")
 	}
@@ -43,15 +44,16 @@ func (mm mockMonitor) Connect() error {
 	return nil
 }
 
-func (mm mockMonitor) Disconnect() error {
+func (mm *mockMonitor) Disconnect() error {
 	if mm.alwaysFail {
 		return errors.New("fail")
 	}
 
+	mm.disconnected = true
 	return nil
 }
 
-func (mm mockMonitor) Run(cmd []byte) ([]byte, error) {
+func (mm *mockMonitor) Run(cmd []byte) ([]byte, error) {
 	if mm.alwaysFail {
 		return []byte(""), errors.New("fail")
 	}
@@ -91,7 +93,7 @@ func (mm mockMonitor) Run(cmd []byte) ([]byte, error) {
 	return []byte("{}"), fmt.Errorf("invalid command %q", string(cmd))
 }
 
-func (mm mockMonitor) runBlockCommand(cmd []byte) ([]byte, bool) {
+func (mm *mockMonitor) runBlockCommand(cmd []byte) ([]byte, bool) {
 	switch string(cmd) {
 	case `{"execute":"block-job-complete","arguments":{"device":"drive-virtio-disk0"}}`:
 		return mockSuccessJSON, true
@@ -114,7 +116,7 @@ func (mm mockMonitor) runBlockCommand(cmd []byte) ([]byte, bool) {
 	return nil, false
 }
 
-func (mm mockMonitor) runQueryCommand(cmd []byte) ([]byte, bool) {
+func (mm *mockMonitor) runQueryCommand(cmd []byte) ([]byte, bool) {
 	switch string(cmd) {
 	case `{"execute":"query-commands"}`:
 		return []byte(`{"return":[{"name":"query-rocker-of-dpa-groups"},{"name":"query-rocker-of-dpa-flows"},{"name":"query-rocker-ports"},{"name":"query-rocker"},{"name":"block-set-write-threshold"},{"name":"x-input-send-event"},{"name":"trace-event-set-state"},{"name":"trace-event-get-state"},{"name":"rtc-reset-reinjection"},{"name":"query-acpi-ospm-status"},{"name":"query-memory-devices"},{"name":"query-memdev"},{"name":"blockdev-change-medium"},{"name":"query-named-block-nodes"},{"name":"x-blockdev-insert-medium"},{"name":"x-blockdev-remove-medium"},{"name":"blockdev-close-tray"},{"name":"blockdev-open-tray"},{"name":"x-blockdev-del"},{"name":"blockdev-add"},{"name":"query-rx-filter"},{"name":"chardev-remove"},{"name":"chardev-add"},{"name":"query-tpm-types"},{"name":"query-tpm-models"},{"name":"query-tpm"},{"name":"query-target"},{"name":"query-cpu-definitions"},{"name":"query-machines"},{"name":"device-list-properties"},{"name":"qom-list-types"},{"name":"change-vnc-password"},{"name":"nbd-server-stop"},{"name":"nbd-server-add"},{"name":"nbd-server-start"},{"name":"qom-get"},{"name":"qom-set"},{"name":"qom-list"},{"name":"query-block-jobs"},{"name":"query-balloon"},{"name":"query-migrate-parameters"},{"name":"migrate-set-parameters"},{"name":"query-migrate-capabilities"},{"name":"migrate-set-capabilities"},{"name":"query-migrate"},{"name":"query-command-line-options"},{"name":"query-uuid"},{"name":"query-name"},{"name":"query-spice"},{"name":"query-vnc-servers"},{"name":"query-vnc"},{"name":"query-mice"},{"name":"query-status"},{"name":"query-kvm"},{"name":"query-pci"},{"name":"query-iothreads"},{"name":"query-cpus"},{"name":"query-blockstats"},{"name":"query-block"},{"name":"query-chardev-backends"},{"name":"query-chardev"},{"name":"query-qmp-schema"},{"name":"query-events"},{"name":"query-commands"},{"name":"query-version"},{"name":"human-monitor-command"},{"name":"qmp_capabilities"},{"name":"add_client"},{"name":"expire_password"},{"name":"set_password"},{"name":"block_set_io_throttle"},{"name":"block_passwd"},{"name":"query-fdsets"},{"name":"remove-fd"},{"name":"add-fd"},{"name":"closefd"},{"name":"getfd"},{"name":"set_link"},{"name":"balloon"},{"name":"change-backing-file"},{"name":"drive-mirror"},{"name":"blockdev-snapshot-delete-internal-sync"},{"name":"blockdev-snapshot-internal-sync"},{"name":"blockdev-snapshot"},{"name":"blockdev-snapshot-sync"},{"name":"block-dirty-bitmap-clear"},{"name":"block-dirty-bitmap-remove"},{"name":"block-dirty-bitmap-add"},{"name":"transaction"},{"name":"block-job-complete"},{"name":"block-job-resume"},{"name":"block-job-pause"},{"name":"block-job-cancel"},{"name":"block-job-set-speed"},{"name":"blockdev-backup"},{"name":"drive-backup"},{"name":"block-commit"},{"name":"block-stream"},{"name":"block_resize"},{"name":"object-del"},{"name":"object-add"},{"name":"netdev_del"},{"name":"netdev_add"},{"name":"query-dump-guest-memory-capability"},{"name":"dump-guest-memory"},{"name":"client_migrate_info"},{"name":"migrate_set_downtime"},{"name":"migrate_set_speed"},{"name":"query-migrate-cache-size"},{"name":"migrate-start-postcopy"},{"name":"migrate-set-cache-size"},{"name":"migrate-incoming"},{"name":"migrate_cancel"},{"name":"migrate"},{"name":"xen-set-global-dirty-log"},{"name":"xen-save-devices-state"},{"name":"ringbuf-read"},{"name":"ringbuf-write"},{"name":"inject-nmi"},{"name":"pmemsave"},{"name":"memsave"},{"name":"cpu-add"},{"name":"cpu"},{"name":"send-key"},{"name":"device_del"},{"name":"device_add"},{"name":"system_powerdown"},{"name":"system_reset"},{"name":"system_wakeup"},{"name":"cont"},{"name":"stop"},{"name":"screendump"},{"name":"change"},{"name":"eject"},{"name":"quit"}],"id":"libvirt-36"}`), true
@@ -133,7 +135,7 @@ func (mm mockMonitor) runQueryCommand(cmd []byte) ([]byte, bool) {
 	return nil, false
 }
 
-func (mm mockMonitor) Events() (<-chan qmp.Event, error) {
+func (mm *mockMonitor) Events() (<-chan qmp.Event, error) {
 	if mm.alwaysFail {
 		return nil, errors.New("fail")
 	}

--- a/version_test.go
+++ b/version_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	m := mockMonitor{}
+	m := &mockMonitor{}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {
@@ -53,7 +53,7 @@ func TestVersionMonitorFail(t *testing.T) {
 }
 
 func TestVersionInvalidJSON(t *testing.T) {
-	m := mockMonitor{invalidJSON: true}
+	m := &mockMonitor{invalidJSON: true}
 
 	d, err := NewDomain(m, "foo")
 	if err != nil {


### PR DESCRIPTION
Instead of adding an option to `hypervisor.Hypervisor` to disconnect individual domains, let's allow `qemu.Domain` to "own" its underlying `qmp.Monitor`, and handle disconnecting it when `Domain.Close()` is called.