### PR TITLE
Extend the CPU struct

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Luis Sagastume  <lsagastume1990@gmail.com>
 Nedim Dedic     <nedim_dedic@yahoo.com>
 Roberto J Rojas <robertojrojas@gmail.com>
 Marko Mudrinic  <mudrinic.mare@gmail.com>
+Markus Freitag <fmarkus@mailbox.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -15,4 +15,4 @@ Luis Sagastume  <lsagastume1990@gmail.com>
 Nedim Dedic     <nedim_dedic@yahoo.com>
 Roberto J Rojas <robertojrojas@gmail.com>
 Marko Mudrinic  <mudrinic.mare@gmail.com>
-Markus Freitag <fmarkus@mailbox.org>
+Markus Freitag  <fmarkus@mailbox.org>

--- a/qemu/cpu.go
+++ b/qemu/cpu.go
@@ -16,8 +16,9 @@ package qemu
 
 // CPU represents a QEMU CPU.
 type CPU struct {
-	CPU     int  `json:"cpu"`
-	Current bool `json:"current"`
-	Halted  bool `json:"halted"`
-	PC      int  `json:"pc"`
+	CPU      int  `json:"cpu"`
+	Current  bool `json:"current"`
+	Halted   bool `json:"halted"`
+	PC       int  `json:"pc"`
+	ThreadID int  `json:"thread_id"`
 }


### PR DESCRIPTION
It would be useful to be able to get the ThreadID of a domains CPU. Therefore add `thread_id` as an attribute to the CPU struct.