### PR TITLE
domain: Add a function to get the qemu package version

### DIFF
--- a/qemu/domain.go
+++ b/qemu/domain.go
@@ -346,6 +346,17 @@ func (d *Domain) Version() (string, error) {
 	return response.Return.String(), nil
 }
 
+// PackageVersion returns the domain's QEMU package version, the full build
+// information for QEMU.
+func (d *Domain) PackageVersion() (string, error) {
+	vers, err := d.rm.QueryVersion()
+	if err != nil {
+		return "", err
+	}
+
+	return vers.Package, nil
+}
+
 // Events streams QEMU QMP events.
 // Two channels are returned, the first contains events emitted by the domain.
 // The second is used to signal completion of event processing.

--- a/qemu/version_test.go
+++ b/qemu/version_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/digitalocean/go-qemu/qmp"
+	"github.com/digitalocean/go-qemu/qmp/raw"
 )
 
 func TestVersion(t *testing.T) {
@@ -46,5 +47,35 @@ func TestVersion(t *testing.T) {
 	expected := "2.5.0"
 	if v != expected {
 		t.Errorf("expected version %q, instead got %q", expected, v)
+	}
+}
+
+func TestPackageVersion(t *testing.T) {
+	result := raw.VersionInfo{}
+	result.Qemu.Major = 2
+	result.Qemu.Minor = 8
+	result.Qemu.Micro = 0
+	result.Package = "(Debian 1:2.8+dfsg-3ubuntu2.4)"
+
+	d, done := testDomain(t, func(cmd qmp.Command) (interface{}, error) {
+		if want, got := "query-version", cmd.Execute; want != got {
+			t.Fatalf("unexpected QMP command:\n- want: %q\n-  got: %q",
+				want, got)
+		}
+
+		return success{
+			Return: result,
+		}, nil
+	})
+	defer done()
+
+	v, err := d.PackageVersion()
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := "(Debian 1:2.8+dfsg-3ubuntu2.4)"
+	if v != expected {
+		t.Errorf("expected package version %q, instead got %q", expected, v)
 	}
 }

--- a/qmp/raw/spec.txt
+++ b/qmp/raw/spec.txt
@@ -9513,13 +9513,16 @@
 # An enumeration of TPM types
 #
 # @passthrough: TPM passthrough type
+# @emulator: Software Emulator TPM type
+#            Since: 2.11
 #
 # Since: 1.5
 ##
 {
   "enum": "TpmType",
   "data": [
-    "passthrough"
+    "passthrough",
+    "emulator"
   ]
 }
 
@@ -9535,7 +9538,7 @@
 # Example:
 #
 # -> { "execute": "query-tpm-types" }
-# <- { "return": [ "passthrough" ] }
+# <- { "return": [ "passthrough", "emulator" ] }
 #
 ##
 {
@@ -9566,18 +9569,36 @@
 }
 
 ##
+# @TPMEmulatorOptions:
+#
+# Information about the TPM emulator type
+#
+# @chardev: Name of a unix socket chardev
+#
+# Since: 2.11
+##
+{
+  "struct": "TPMEmulatorOptions",
+  "data": {
+    "chardev": "str"
+  }
+}
+
+##
 # @TpmTypeOptions:
 #
 # A union referencing different TPM backend types' configuration options
 #
 # @type: 'passthrough' The configuration options for the TPM passthrough type
+#        'emulator' The configuration options for TPM emulator backend type
 #
 # Since: 1.5
 ##
 {
   "union": "TpmTypeOptions",
   "data": {
-    "passthrough": "TPMPassthroughOptions"
+    "passthrough": "TPMPassthroughOptions",
+    "emulator": "TPMEmulatorOptions"
   }
 }
 


### PR DESCRIPTION
This is a more detailed version string than is returned by Version(), allowing callers to distinguish between patch builds.