### PR TITLE
Create a SocketMonitor by listening for a Qemu connection.

### DIFF
--- a/qemu/string.gen.go
+++ b/qemu/string.gen.go
@@ -16,7 +16,7 @@
 
 package qemu
 
-import "fmt"
+import "strconv"
 
 const _Status_name = "StatusDebugStatusInMigrateStatusInternalErrorStatusIOErrorStatusPausedStatusPostMigrateStatusPreLaunchStatusFinishMigrateStatusRestoreVMStatusRunningStatusSaveVMStatusShutdownStatusSuspendedStatusWatchdogStatusGuestPanicked"
 
@@ -24,7 +24,7 @@ var _Status_index = [...]uint8{0, 11, 26, 45, 58, 70, 87, 102, 121, 136, 149, 16
 
 func (i Status) String() string {
 	if i < 0 || i >= Status(len(_Status_index)-1) {
-		return fmt.Sprintf("Status(%d)", i)
+		return "Status(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _Status_name[_Status_index[i]:_Status_index[i+1]]
 }

--- a/qmp/raw/spec.txt
+++ b/qmp/raw/spec.txt
@@ -1,5 +1,5 @@
 
-##QEMU SPECIFICATION VERSION:  2.10.50
+##QEMU SPECIFICATION VERSION:  2.11.50
 
 
 # Whitelists to permit QAPI rule violations; think twice before you
@@ -4460,6 +4460,12 @@
 # BLOCK_JOB_CANCELLED event.  Before that happens the job is still visible when
 # enumerated using query-block-jobs.
 #
+# Note that if you issue 'block-job-cancel' after 'drive-mirror' has indicated
+# (via the event BLOCK_JOB_READY) that the source and destination are
+# synchronized, then the event triggered by this command changes to
+# BLOCK_JOB_COMPLETED, to indicate that the mirroring has ended and the
+# destination now has a point-in-time copy tied to the time of the cancellation.
+#
 # For streaming, the image file retains its backing file unless the streaming
 # operation happens to complete just as it is being cancelled.  A new streaming
 # operation can be started at a later time to finish copying all data from the
@@ -5837,8 +5843,11 @@
 #                 This option is required on the top level of blockdev-add.
 # @discard:       discard-related options (default: ignore)
 # @cache:         cache-related options
-# @read-only:     whether the block device should be read-only
-#                 (default: false)
+# @read-only:     whether the block device should be read-only (default: false).
+#                 Note that some block drivers support only read-only access,
+#                 either generally or in certain configurations. In this case,
+#                 the default value does not work and the option must be
+#                 specified explicitly.
 # @detect-zeroes: detect and optimize zero writes (Since 2.1)
 #                 (default: off)
 # @force-share:   force share all permission on added nodes.
@@ -10839,6 +10848,13 @@
 # @ac_bookmarks: since 2.10
 # altgr, altgr_r: dropped in 2.10
 #
+# 'sysrq' was mistakenly added to hack around the fact that
+# the ps2 driver was not generating correct scancodes sequences
+# when 'alt+print' was pressed. This flaw is now fixed and the
+# 'sysrq' key serves no further purpose. Any further use of
+# 'sysrq' will be transparently changed to 'print', so they
+# are effectively synonyms.
+#
 # Since: 1.3.0
 #
 ##
@@ -11477,6 +11493,11 @@
 # @colo: VM is in the process of fault tolerance, VM can not get into this
 #        state unless colo capability is enabled for migration. (since 2.8)
 #
+# @pre-switchover: Paused before device serialisation. (since 2.11)
+#
+# @device: During device serialisation when pause-before-switchover is enabled
+#        (since 2.11)
+#
 # Since: 2.3
 #
 ##
@@ -11491,7 +11512,9 @@
     "postcopy-active",
     "completed",
     "failed",
-    "colo"
+    "colo",
+    "pre-switchover",
+    "device"
   ]
 }
 
@@ -11741,6 +11764,9 @@
 # @return-path: If enabled, migration will use the return path even
 #               for precopy. (since 2.10)
 #
+# @pause-before-switchover: Pause outgoing migration before serialising device
+#          state and before disabling block IO (since 2.11)
+#
 # @x-multifd: Use more than one fd for migration (since 2.11)
 #
 # Since: 1.2
@@ -11759,6 +11785,7 @@
     "release-ram",
     "block",
     "return-path",
+    "pause-before-switchover",
     "x-multifd"
   ]
 }
@@ -11900,8 +11927,13 @@
 #                     number of sockets used for migration.  The
 #                     default value is 2 (since 2.11)
 #
-# @x-multifd-page-count: Number of pages sent together to a thread
+# @x-multifd-page-count: Number of pages sent together to a thread.
 #                        The default value is 16 (since 2.11)
+#
+# @xbzrle-cache-size: cache size to be used by XBZRLE migration.  It
+#                     needs to be a multiple of the target page size
+#                     and a power of 2
+#                     (Since 2.11)
 #
 # Since: 2.4
 ##
@@ -11920,7 +11952,8 @@
     "x-checkpoint-delay",
     "block-incremental",
     "x-multifd-channels",
-    "x-multifd-page-count"
+    "x-multifd-page-count",
+    "xbzrle-cache-size"
   ]
 }
 
@@ -11983,9 +12016,13 @@
 #                     number of sockets used for migration.  The
 #                     default value is 2 (since 2.11)
 #
-# @x-multifd-page-count: Number of pages sent together to a thread
+# @x-multifd-page-count: Number of pages sent together to a thread.
 #                        The default value is 16 (since 2.11)
 #
+# @xbzrle-cache-size: cache size to be used by XBZRLE migration.  It
+#                     needs to be a multiple of the target page size
+#                     and a power of 2
+#                     (Since 2.11)
 # Since: 2.4
 ##
 # TODO either fuse back into MigrationParameters, or make
@@ -12005,7 +12042,8 @@
     "*x-checkpoint-delay": "int",
     "*block-incremental": "bool",
     "*x-multifd-channels": "int",
-    "*x-multifd-page-count": "int"
+    "*x-multifd-page-count": "int",
+    "*xbzrle-cache-size": "size"
   }
 }
 
@@ -12086,9 +12124,13 @@
 #                     number of sockets used for migration.
 #                     The default value is 2 (since 2.11)
 #
-# @x-multifd-page-count: Number of pages sent together to a thread
+# @x-multifd-page-count: Number of pages sent together to a thread.
 #                        The default value is 16 (since 2.11)
 #
+# @xbzrle-cache-size: cache size to be used by XBZRLE migration.  It
+#                     needs to be a multiple of the target page size
+#                     and a power of 2
+#                     (Since 2.11)
 # Since: 2.4
 ##
 {
@@ -12106,7 +12148,8 @@
     "*x-checkpoint-delay": "int",
     "*block-incremental": "bool",
     "*x-multifd-channels": "int",
-    "*x-multifd-page-count": "int"
+    "*x-multifd-page-count": "int",
+    "*xbzrle-cache-size": "size"
   }
 }
 
@@ -12365,6 +12408,14 @@
 }
 
 ##
+{
+  "command": "migrate-continue",
+  "data": {
+    "state": "MigrationStatus"
+  }
+}
+
+##
 # @migrate_set_downtime:
 #
 # Set maximum tolerated downtime for migration.
@@ -12428,6 +12479,8 @@
 #
 # Returns: nothing on success
 #
+# Notes: This command is deprecated in favor of 'migrate-set-parameters'
+#
 # Since: 1.2
 #
 # Example:
@@ -12450,6 +12503,8 @@
 # Query migration XBZRLE cache size
 #
 # Returns: XBZRLE cache size in bytes
+#
+# Notes: This command is deprecated in favor of 'query-migrate-parameters'
 #
 # Since: 1.2
 #
@@ -12556,6 +12611,9 @@
 # data. See xen-save-devices-state.txt for a description of the binary
 # format.
 #
+# @live: Optional argument to ask QEMU to treat this command as part of a live
+# migration. Default to true. (since 2.11)
+#
 # Returns: Nothing on success
 #
 # Since: 1.1
@@ -12570,7 +12628,8 @@
 {
   "command": "xen-save-devices-state",
   "data": {
-    "filename": "str"
+    "filename": "str",
+    "*live": "bool"
   }
 }
 
@@ -15834,6 +15893,12 @@
 # BLOCK_JOB_CANCELLED event.  Before that happens the job is still visible when
 # enumerated using query-block-jobs.
 #
+# Note that if you issue 'block-job-cancel' after 'drive-mirror' has indicated
+# (via the event BLOCK_JOB_READY) that the source and destination are
+# synchronized, then the event triggered by this command changes to
+# BLOCK_JOB_COMPLETED, to indicate that the mirroring has ended and the
+# destination now has a point-in-time copy tied to the time of the cancellation.
+#
 # For streaming, the image file retains its backing file unless the streaming
 # operation happens to complete just as it is being cancelled.  A new streaming
 # operation can be started at a later time to finish copying all data from the
@@ -17211,8 +17276,11 @@
 #                 This option is required on the top level of blockdev-add.
 # @discard:       discard-related options (default: ignore)
 # @cache:         cache-related options
-# @read-only:     whether the block device should be read-only
-#                 (default: false)
+# @read-only:     whether the block device should be read-only (default: false).
+#                 Note that some block drivers support only read-only access,
+#                 either generally or in certain configurations. In this case,
+#                 the default value does not work and the option must be
+#                 specified explicitly.
 # @detect-zeroes: detect and optimize zero writes (Since 2.1)
 #                 (default: off)
 # @force-share:   force share all permission on added nodes.
@@ -22850,12 +22918,12 @@
 # -> { "execute": "query-hotpluggable-cpus" }
 # <- {"return": [
 #      {
-#         "type": "qemu-s390-cpu", "vcpus-count": 1,
+#         "type": "qemu-s390x-cpu", "vcpus-count": 1,
 #         "props": { "core-id": 1 }
 #      },
 #      {
 #         "qom-path": "/machine/unattached/device[0]",
-#         "type": "qemu-s390-cpu", "vcpus-count": 1,
+#         "type": "qemu-s390x-cpu", "vcpus-count": 1,
 #         "props": { "core-id": 0 }
 #      }
 #    ]}

--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -68,19 +68,19 @@ func NewSocketMonitor(network, addr string, timeout time.Duration) (*SocketMonit
 	return mon, nil
 }
 
-// Listen creates a new SocketMonitor by listening to the provided socket file or address.
+// Listen creates a new SocketMonitor listening for a single connection to the provided socket file or address.
 // An error is returned if unable to listen at the specified file path or port.
 //
-// Listen willl wait for a QEMU socket connection using a variety connection types:
+// Listen will wait for a QEMU socket connection using a variety connection types:
 //	Listen("unix", "/var/lib/qemu/example.monitor")
 //	Listen("tcp", "0.0.0.0:4444")
 func Listen(network, addr string) (*SocketMonitor, error) {
-	listener, listenerErr := net.Listen(network, addr)
-	if listenerErr != nil {
-		return nil, listenerErr
+	l, err := net.Listen(network, addr)
+	if err != nil {
+		return nil, err
 	}
-	c, err := listener.Accept()
-	defer listener.Close()
+	c, err := l.Accept()
+	defer l.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -68,14 +68,19 @@ func NewSocketMonitor(network, addr string, timeout time.Duration) (*SocketMonit
 	return mon, nil
 }
 
-// NewListeningSocketMonitor listens for a monitor socket connection from Qemu.
-// An error is returned if the connection fails to accept.
-func NewListeningSocketMonitor(network, addr string) (*SocketMonitor, error) {
+// Listen creates a new SocketMonitor by listening to the provided socket file or address.
+// An error is returned if unable to listen at the specified file path or port.
+//
+// Listen willl wait for a QEMU socket connection using a variety connection types:
+//	Listen("unix", "/var/lib/qemu/example.monitor")
+//	Listen("tcp", "0.0.0.0:4444")
+func Listen(network, addr string) (*SocketMonitor, error) {
 	listener, listenerErr := net.Listen(network, addr)
 	if listenerErr != nil {
 		return nil, listenerErr
 	}
 	c, err := listener.Accept()
+	defer listener.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -68,6 +68,26 @@ func NewSocketMonitor(network, addr string, timeout time.Duration) (*SocketMonit
 	return mon, nil
 }
 
+// NewListeningSocketMonitor listens for a monitor socket connection from Qemu.
+// An error is returned if the connection fails to accept.
+func NewListeningSocketMonitor(network, addr string) (*SocketMonitor, error) {
+	listener, listenerErr := net.Listen(network, addr)
+	if listenerErr != nil {
+		return nil, listenerErr
+	}
+	c, err := listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	mon := &SocketMonitor{
+		c:         c,
+		listeners: new(int32),
+	}
+
+	return mon, nil
+}
+
 // Disconnect closes the QEMU monitor socket connection.
 func (mon *SocketMonitor) Disconnect() error {
 	atomic.StoreInt32(mon.listeners, 0)


### PR DESCRIPTION
Hello! Awesome work here!

In our use case, we instruct Qemu to connect to our processes's socket instead of racing to connect to Qemu's generated socket. This is a big win for us in terms of concurrency since we no longer need to poll for Qemu's socket after spawning a Qemu process.

We pass `-chardev socket,id=qmp,path=qmp.sock` into Qemu instead of `-chardev socket,id=qmp,path=qmp.sock,server`

If this change makes sense, I am happy to refactor it and make the code more DRY. I can also add docs and tests for this change.