### PR TITLE
qemu/block: fixes deadlock in waitForSignal

### DIFF
--- a/hypervisor/example_test.go
+++ b/hypervisor/example_test.go
@@ -23,10 +23,6 @@ import (
 	"github.com/digitalocean/go-qemu/qmp/qmptest"
 )
 
-// ExampleStub exists to prevent godoc from treating this as a "whole-file"
-// example, and showing the code for the unexported types.
-func ExampleStub() {}
-
 func ExampleNew() {
 	// Create a hypervisor.Hypervisor using an in-memory hypervisor.Driver,
 	// that returns a fixed list of three domains.

--- a/internal/qmp-gen/main.go
+++ b/internal/qmp-gen/main.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 )
 
-const specURL = `https://raw.githubusercontent.com/qemu/qemu/master/qapi-schema.json`
+const specURL = `https://raw.githubusercontent.com/qemu/qemu/stable-2.11/qapi-schema.json`
 
 var (
 	inputSpec  = flag.String("input", specURL, "Input spec")

--- a/qemu/example_test.go
+++ b/qemu/example_test.go
@@ -23,10 +23,6 @@ import (
 	"github.com/digitalocean/go-qemu/qmp/qmptest"
 )
 
-// ExampleStub exists to prevent godoc from treating this as a "whole-file"
-// example, and showing the code for the unexported exampleMonitor type.
-func ExampleStub() {}
-
 // This example demonstrates how to use qemu.NewDomain with a qmp.Monitor to
 // perform actions on a Domain.
 //

--- a/qmp/raw/spec.txt
+++ b/qmp/raw/spec.txt
@@ -1,5 +1,5 @@
 
-##QEMU SPECIFICATION VERSION:  2.11.50
+##QEMU SPECIFICATION VERSION:  2.11.2
 
 
 # Whitelists to permit QAPI rule violations; think twice before you


### PR DESCRIPTION
Previously, waitForSignal executed a command prior to listening on the event stream. If an event arrived prior to the commands return, the event stream would block forever.