### PR TITLE
Drain channel on disconnect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - rm qemu-${QEMU}.tar.${QEMU_EXT} libvirt-${LIBVIRT}.tar.${LIBVIRT_EXT}
   
 before_install:
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - go get golang.org/x/tools/cmd/stringer
 
 before_script:

--- a/qemu/domain.go
+++ b/qemu/domain.go
@@ -372,6 +372,14 @@ func (d *Domain) Events() (chan qmp.Event, chan struct{}, error) {
 	// handle disconnection
 	go func() {
 		<-done
+		// drain anything that gets sent on the channel
+		// because the disconnect won't be processed if the
+		// listenAndServe loop is waiting for the listener
+		// to read from the unbuffered channel.
+		go func() {
+			for range stream {
+			}
+		}()
 		d.disconnect <- stream
 		close(stream)
 		close(done)

--- a/qemu/domain_test.go
+++ b/qemu/domain_test.go
@@ -578,7 +578,7 @@ func TestEvents(t *testing.T) {
 }
 
 // Test when a listener connects, but disconnects without
-// receiving from the events chaannel returned.
+// receiving from the events channel returned.
 func TestEventsDerelictListener(t *testing.T) {
 	d, done := testDomain(t, nil)
 	defer done()

--- a/qemu/string.gen.go
+++ b/qemu/string.gen.go
@@ -18,6 +18,27 @@ package qemu
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[StatusDebug-0]
+	_ = x[StatusFinishMigrate-7]
+	_ = x[StatusGuestPanicked-14]
+	_ = x[StatusIOError-3]
+	_ = x[StatusInMigrate-1]
+	_ = x[StatusInternalError-2]
+	_ = x[StatusPaused-4]
+	_ = x[StatusPostMigrate-5]
+	_ = x[StatusPreLaunch-6]
+	_ = x[StatusRestoreVM-8]
+	_ = x[StatusRunning-9]
+	_ = x[StatusSaveVM-10]
+	_ = x[StatusShutdown-11]
+	_ = x[StatusSuspended-12]
+	_ = x[StatusWatchdog-13]
+}
+
 const _Status_name = "StatusDebugStatusInMigrateStatusInternalErrorStatusIOErrorStatusPausedStatusPostMigrateStatusPreLaunchStatusFinishMigrateStatusRestoreVMStatusRunningStatusSaveVMStatusShutdownStatusSuspendedStatusWatchdogStatusGuestPanicked"
 
 var _Status_index = [...]uint8{0, 11, 26, 45, 58, 70, 87, 102, 121, 136, 149, 161, 175, 190, 204, 223}


### PR DESCRIPTION
There's a race condition when a listener initiates a disconnect without continuing to receive on the previously returned unbuffered channel; thereby blocking the logic that does the disconnect.

The first commit is a unit test that demonstrates the scenario, the second is a relatively quick and dirty fix.