### PR TITLE
qmp/rpc: Fix upstream API change

### DIFF
--- a/qmp/rpc.go
+++ b/qmp/rpc.go
@@ -15,6 +15,7 @@
 package qmp
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 
@@ -59,7 +60,7 @@ func (rpc *LibvirtRPCMonitor) Disconnect() error {
 // an error will be returned. Errors encountered during streaming will
 // cause the returned event channel to be closed.
 func (rpc *LibvirtRPCMonitor) Events() (<-chan Event, error) {
-	events, err := rpc.l.Events(rpc.Domain)
+	events, err := rpc.l.SubscribeQEMUEvents(context.Background(), rpc.Domain)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes API change https://github.com/digitalocean/go-libvirt/commit/e2a69bcd5bd163f61a7e222cf915101e7e11b1c6 

Fixes #167

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>