### PR TITLE
[qmp] Add RunWithFile to socket client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/digitalocean/go-libvirt v0.0.0-20201209184759-e2a69bcd5bd1
 	github.com/fatih/camelcase v1.0.0
+	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 )

--- a/go.sum
+++ b/go.sum
@@ -22,7 +22,10 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200711155855-7342f9734a7d h1:F3OmlXCzYtG9YE6tXDnUOlJBzVzHF8EcmZ1yTJlcgIk=

--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
 
 // A SocketMonitor is a Monitor which speaks directly to a QEMU Machine Protocol
@@ -237,7 +235,7 @@ func (mon *SocketMonitor) RunWithFile(command []byte, file *os.File) ([]byte, er
 		}
 
 		// Send the command along with the file descriptor.
-		oob := unix.UnixRights(int(file.Fd()))
+		oob := getUnixRights(file)
 		if _, _, err := unixConn.WriteMsgUnix(command, oob, nil); err != nil {
 			return nil, err
 		}

--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -34,6 +34,9 @@ type SocketMonitor struct {
 	// QEMU version reported by a connected monitor socket.
 	Version *Version
 
+	// QEMU QMP capabiltiies reported by a connected monitor socket.
+	Capabilities []string
+
 	// Underlying connection
 	c net.Conn
 
@@ -119,6 +122,7 @@ func (mon *SocketMonitor) Connect() error {
 		return err
 	}
 	mon.Version = &ban.QMP.Version
+	mon.Capabilities = ban.QMP.Capabilities
 
 	// Issue capabilities handshake
 	cmd := Command{Execute: qmpCapabilities}
@@ -224,6 +228,7 @@ func (mon *SocketMonitor) Run(command []byte) ([]byte, error) {
 // banner is a wrapper type around a Version.
 type banner struct {
 	QMP struct {
+		Capabilities []string `json:"capabilities"`
 		Version Version `json:"version"`
 	} `json:"QMP"`
 }

--- a/qmp/socket_unix.go
+++ b/qmp/socket_unix.go
@@ -1,0 +1,27 @@
+// Copyright 2016 The go-qemu Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package qmp
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func getUnixRights(file *os.File) []byte {
+	return unix.UnixRights(int(file.Fd()))
+}

--- a/qmp/socket_windows.go
+++ b/qmp/socket_windows.go
@@ -1,0 +1,25 @@
+// Copyright 2016 The go-qemu Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package qmp
+
+import (
+	"os"
+)
+
+func getUnixRights(file *os.File) []byte {
+	return nil
+}


### PR DESCRIPTION
This PR does two main things:
 - Record the capabilities returned by QEMU at connection time (and make them available through `Capabilities`)
 - Introduce a new `RunWithFile` function which behaves like `Run` but takes an `os.File` as an argument, using the out-of-band unix socket capability to send the file as part of the monitor command.

We're adding support for hibernate (dump state to disk) and for live migration to LXD and need this feature to send the migration target file descriptor over to QEMU.