### PR TITLE
In `Events` functions, always close the returned channel when done

### DIFF
--- a/qmp/rpc.go
+++ b/qmp/rpc.go
@@ -67,11 +67,11 @@ func (rpc *LibvirtRPCMonitor) Events(ctx context.Context) (<-chan Event, error) 
 
 	c := make(chan Event)
 	go func() {
+		defer close(c)
 		// process events
 		for e := range events {
 			qe, err := qmpEvent(&e)
 			if err != nil {
-				close(c)
 				break
 			}
 


### PR DESCRIPTION
The channel returned by `qmp.LibvirtRPCMonitor.Events` will now be closed
regardless of how the goroutine populating the channel exits.

Specifically, this channel was not being closed when the underlying channel
returned from `SubscribeQEMUEvents` was closed. This happens for various
reasons, but one important one is when the underlying libvirtd connection is
closed.

This change caused the `qemu.Domain.Events` to always return the default value
once the underlying monitor had closed, and so this code was reworked so that
this channel would also close.

The changes to `qemu.Domain` required some restructuring of some old,
unidiomatic Go code, but I have not changed the API signatures, nor the
semantics of using the code outside receiving a channel which will now close.
This was made possible by ensuring that only the main broadcast loop has
ownership over a listener's (i.e. channel) lifetime. More can be done (`go test
-race` indicates there are race conditions), but it falls outside the scope of
this commit.

I also had to fix some races in tests in `domain_test.go` to build confidence in
my changes.

These changes allow callers to rely on Go channel idioms for taking action when
a channel will receive no more messages.