### PR TITLE
Remove uses of package time from unit tests (where feasible) 

### DIFF
--- a/qemu/domain_test.go
+++ b/qemu/domain_test.go
@@ -554,12 +554,8 @@ func TestEvents(t *testing.T) {
 		t.Error(err)
 	}
 
-	select {
-	case <-events:
-		close(stop)
-	case <-time.After(time.Millisecond * 20):
-		t.Error("expected event")
-	}
+	<-events
+	close(stop)
 }
 
 // Test when a listener connects, but disconnects without
@@ -582,8 +578,6 @@ func TestEventsDerelictListener(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
-	time.Sleep(200 * time.Millisecond)
 	close(stop)
 
 	t.Log("Attempting to drain events2")
@@ -677,7 +671,6 @@ func (t *testMonitor) Events(ctx context.Context) (<-chan qmp.Event, error) {
 					return
 				case c <- qmp.Event{Event: blockJobError}:
 				}
-				time.Sleep(10 * time.Millisecond)
 				continue
 			}
 
@@ -685,7 +678,6 @@ func (t *testMonitor) Events(ctx context.Context) (<-chan qmp.Event, error) {
 			case <-ctx.Done():
 			case c <- qmp.Event{Event: events[i]}:
 			}
-			time.Sleep(10 * time.Millisecond)
 
 			i = (i + 1) % len(events)
 		}

--- a/qmp/rpc_test.go
+++ b/qmp/rpc_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/digitalocean/go-libvirt"
 	"github.com/digitalocean/go-libvirt/libvirttest"
@@ -182,19 +181,13 @@ func TestLibvirtRPCMonitorEvents(t *testing.T) {
 	}
 
 	go func() {
-		var e Event
-		select {
-		case e = <-stream:
-		case <-time.After(time.Second * 1):
-			t.Error("expected event, received timeout")
-		}
+		defer close(done)
+		got := <-stream
 
 		expected := "drive-ide0-0-0"
-		if e.Data["device"] != expected {
-			t.Errorf("expected device %q, got %q", expected, e.Data["device"])
+		if got.Data["device"] != expected {
+			t.Errorf("expected device %q, got %q", expected, got.Data["device"])
 		}
-
-		done <- struct{}{}
 	}()
 
 	// send an event to the listener goroutine

--- a/qmp/socket_test.go
+++ b/qmp/socket_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -28,7 +27,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 )
 
 func TestSocketMonitorConnectDisconnect(t *testing.T) {
@@ -37,19 +35,9 @@ func TestSocketMonitorConnectDisconnect(t *testing.T) {
 }
 
 func TestSocketMonitorListen(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "go-qemu-test")
-	if err != nil {
-		t.Fatalf("failed to create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	sock := filepath.Join(dir, "listener.sock")
-
-	// Fail the test if the socket takes too long to be ready.
-	timer := time.AfterFunc(3*time.Second, func() {
-		panic("took too long to connect to QMP listener")
-	})
-	defer timer.Stop()
 
 	// Ensure that goroutine client stops.
 	var wg sync.WaitGroup
@@ -63,8 +51,6 @@ func TestSocketMonitorListen(t *testing.T) {
 			if _, err := os.Stat(sock); err == nil {
 				break
 			}
-
-			time.Sleep(100 * time.Millisecond)
 		}
 
 		// Attempt to dial the socket before the timeout expires.


### PR DESCRIPTION
These can make unit tests brittle depending on a number of factors that aren't controllable from the unit test suite. Rather than hard-coding these values in, let the test runner `go test -timeout` impose the timeout.