### PR TITLE
add dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This altruistic automaton will automatically apply updates to the go.mod and propose them for merge.

This will be particularly helpful for consuming new changes from go-libvirt, since the libvirttest package is relied upon in this repo.