### PR TITLE
drain stream chan during Disconnect

### DIFF
--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -104,6 +104,9 @@ func (mon *SocketMonitor) Disconnect() error {
 	atomic.StoreInt32(mon.listeners, 0)
 	err := mon.c.Close()
 
+	for range mon.stream {
+	}
+
 	return err
 }
 


### PR DESCRIPTION
Otherwise SocketMonitor.listen will leak since it will block trying to
send the io.EOF err through the channel to a listener that is no longer
listening.

To test this, I modified one of the test cases which goes through a
SocketMonitor.Connect,.Disconnect lifecycle to hang forever, like so:

    diff --git a/qmp/socket_test.go b/qmp/socket_test.go
    index d6eb4a1..c3484ed 100644
    --- a/qmp/socket_test.go
    +++ b/qmp/socket_test.go
    @@ -32,6 +32,9 @@ import (
     func TestSocketMonitorConnectDisconnect(t *testing.T) {
	    _, _, done := testSocket(t)
	    done()
    +
    +       var forever chan struct{}
    +       <-forever
     }

I did this instead of setting a breakpoint because the test suite would
exit the process too quickly.

Then I ran the test, waited a few seconds, and paused the program with
the debugger and looked to see if the SocketMonitor.listen goroutine was
leaked (i.e., is still running post-disconnect with no listeners).

I performed the test without this patch and confirmed
SocketMonitor.listen was leaked, then I performed the same test with
this patch and confirmed it was no longer leaked.