### PR TITLE
Add ThreadID as a new CPU attribute

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Luis Sagastume  <lsagastume1990@gmail.com>
 Nedim Dedic     <nedim_dedic@yahoo.com>
 Roberto J Rojas <robertojrojas@gmail.com>
 Marko Mudrinic  <mudrinic.mare@gmail.com>
+Markus Freitag  <fmarkus@mailbox.org>

--- a/qemu/cpu.go
+++ b/qemu/cpu.go
@@ -16,8 +16,9 @@ package qemu
 
 // CPU represents a QEMU CPU.
 type CPU struct {
-	CPU     int  `json:"cpu"`
-	Current bool `json:"current"`
-	Halted  bool `json:"halted"`
-	PC      int  `json:"pc"`
+	CPU      int  `json:"cpu"`
+	Current  bool `json:"current"`
+	Halted   bool `json:"halted"`
+	PC       int  `json:"pc"`
+	ThreadID int  `json:"thread_id"`
 }


### PR DESCRIPTION
Reposting #149 with authorship intact so this can run against CI.

This change is contemporaneous with the version of the QAPI that's currently generated against, but I suspect it will change in future revisions because I can't find any reference to `query-cpus` in modern QAPI references, only `query-cpus-fast`. I'm only pointing this out because this struct won't be forwards compatible with that CPU info struct, for example, `query-cpus-fast` returns a JSON object where the key is `thread-id` and not `thread_id`.

But, as stated above, this is correct for the version of QAPI that's been ossified here.