### PR TITLE
Allow Disconnect to be used to cancel ongoing Connect call

### DIFF
--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -104,7 +104,9 @@ func (mon *SocketMonitor) Disconnect() error {
 	atomic.StoreInt32(mon.listeners, 0)
 	err := mon.c.Close()
 
-	for range mon.stream {
+	if mon.stream != nil {
+		for range mon.stream {
+		}
 	}
 
 	return err

--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -266,7 +266,7 @@ func (mon *SocketMonitor) RunWithFile(command []byte, file *os.File) ([]byte, er
 type banner struct {
 	QMP struct {
 		Capabilities []string `json:"capabilities"`
-		Version Version `json:"version"`
+		Version      Version  `json:"version"`
 	} `json:"QMP"`
 }
 


### PR DESCRIPTION
And not block forever if mon.stream not initialised yet.

Fixes #200

See https://github.com/lxc/lxd/issues/11892#issuecomment-1607086255