### PR TITLE
Fix has Incorrect privilege reporting in syscall()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/alecthomas/repr v0.1.1
 	github.com/digitalocean/go-libvirt v0.0.0-20220804181439-8648fbde413e
 	github.com/fatih/camelcase v1.0.0
-	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
+	golang.org/x/sys v0.1.0
 )


### PR DESCRIPTION
The project used Go has Incorrect Privilege Reporting in syscall. When called with a non-zero flags parameter, the Faccessat function could incorrectly report that a file is accessible. The `syscall.Faccessat` function checks whether the calling process can access a file. `Faccessat` contains a bug where it checks a file's group permission bits if the process's user is a member of the process's group rather than a member of the file's group.

```diff
- if uint32(gid) == st.Gid || isGroupMember(gid) { 
```
```
	var fmode uint32
	if uint32(uid) == st.Uid {
		fmode = (st.Mode >> 6) & 7
	} else {
		var gid int
		if flags&_AT_EACCESS != 0 {
			gid = Getegid()
		} else {
			gid = Getgid()
		}

		if uint32(gid) == st.Gid || isGroupMember(gid) { // <-- this should be isGroupMember(st.Gid), not gid
			fmode = (st.Mode >> 3) & 7
		} else {
			fmode = st.Mode & 7
		}
	}
```
Since a process's user is usually a member of the process's group, this causes Faccessat to usually check a file's group permissions even if the process's user is not a member of the file's group.

**Impact:**
CWE-269
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`