### PR TITLE
Support set deadline for qmp socket connection

### DIFF
--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -166,6 +166,13 @@ func (mon *SocketMonitor) Events(context.Context) (<-chan Event, error) {
 	return mon.events, nil
 }
 
+// SetRWDeadline sets the read and write deadlines for the underlying socket.
+// Set deadline to prevent the Command from hanging due to other processes
+// (e.g. libvirt) occupying the QEMU monitor socket.
+func (mon *SocketMonitor) SetRWDeadline(t time.Time) error {
+	return mon.c.SetDeadline(t)
+}
+
 // listen listens for incoming data from a QEMU monitor socket.  It determines
 // if the data is an asynchronous event or a response to a command, and returns
 // the data on the appropriate channel.


### PR DESCRIPTION
If some other process(e.g. libvirtd) occupy the qmp socket, run command will hang.

Sometimes we use go-qemu to take over VM when libvirtd stopped, but libvirtd service will start automatically at an undetermined time. Deadline could prevent the impact of race condition.

example:
`

    socket, err := qmp.NewSocketMonitor("unix", sockFile, timeout)
	
    if err != nil {
		return nil, err
	}

	if err := socket.SetRWDeadline(time.Now().Add(timeout)); err != nil {
		return nil, err
	}

	if err := socket.Connect(); err != nil {
		return nil, err
	}
	defer socket.Disconnect()

`