### PR TITLE
ci: use 'stable' and 'oldstable' aliases respectively

### DIFF
--- a/.github/workflows/goqemu.yml
+++ b/.github/workflows/goqemu.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         # track upstream Go's currently supported stable versions.
-        gorelease: ['1.18', '1.19']
+        gorelease: ['stable', 'oldstable']
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This makes it easier to track the supported Go toolchains without turning the GHA workflow file into a treadmill.